### PR TITLE
feat(i18n): add Dutch and English translations

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,6 @@
 import type { Handle } from '@sveltejs/kit';
 import { resolveSession } from '$lib/server/auth/session';
+import { locale } from 'svelte-i18n';
 
 export const handle: Handle = async ({ event, resolve }) => {
 	const token = event.cookies.get('pg_session');
@@ -9,6 +10,11 @@ export const handle: Handle = async ({ event, resolve }) => {
 		event.locals.session = session;
 	} else {
 		event.locals.session = null;
+	}
+
+	const lang = event.request.headers.get('accept-language')?.split(',')[0];
+	if (lang) {
+		locale.set(lang);
 	}
 
 	return resolve(event);

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import pkg from '../../../package.json';
 
 	const year = new Date().getFullYear();
@@ -13,25 +14,25 @@
 <footer>
 	<div class="footer-inner">
 		<div class="footer-brand">
-			<p class="brand-name">PostGuard for Business</p>
-			<p class="brand-tagline">Enterprise-grade identity-based email signing</p>
+			<p class="brand-name">{$_('footer.brandName')}</p>
+			<p class="brand-tagline">{$_('footer.tagline')}</p>
 		</div>
 
 		<div class="footer-links">
 			<div class="link-group">
-				<h4>Product</h4>
-				<a href="/pricing">Pricing</a>
-				<a href="/register">Register</a>
+				<h4>{$_('footer.product')}</h4>
+				<a href="/pricing">{$_('nav.pricing')}</a>
+				<a href="/register">{$_('nav.register')}</a>
 			</div>
 			<div class="link-group">
-				<h4>Resources</h4>
-				<a href="https://postguard.eu" target="_blank" rel="noopener">PostGuard Personal</a>
-				<a href="https://docs.postguard.eu" target="_blank" rel="noopener">Documentation</a>
+				<h4>{$_('footer.resources')}</h4>
+				<a href="https://postguard.eu" target="_blank" rel="noopener">{$_('footer.personal')}</a>
+				<a href="https://docs.postguard.eu" target="_blank" rel="noopener">{$_('footer.docs')}</a>
 			</div>
 		</div>
 
 		<div class="footer-bottom">
-			<p>&copy; {year} PostGuard. All rights reserved.</p>
+			<p>{$_('footer.copyright', { values: { year } })}</p>
 			<span class="version">v{versionLabel}</span>
 		</div>
 	</div>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import ThemeSwitcher from './ThemeSwitcher.svelte';
+	import LocaleSwitcher from './LocaleSwitcher.svelte';
 	import Icon from '@iconify/svelte';
 	import logoLight from '$lib/assets/images/logo.svg';
 	import logoDark from '$lib/assets/images/logo-dark.svg';
@@ -19,9 +21,9 @@
 	}
 
 	const navLinks = $derived([
-		{ href: '/', label: 'Home' },
-		...(showPricing ? [{ href: '/pricing', label: 'Pricing' }] : []),
-		...(showRegister ? [{ href: '/register', label: 'Register' }] : [])
+		{ href: '/', label: $_('nav.home') },
+		...(showPricing ? [{ href: '/pricing', label: $_('nav.pricing') }] : []),
+		...(showRegister ? [{ href: '/register', label: $_('nav.register') }] : [])
 	]);
 </script>
 
@@ -33,18 +35,19 @@
 			<span class="logo-badge">Business</span>
 		</a>
 
-		<nav class="desktop-nav" aria-label="Main navigation">
+		<nav class="desktop-nav" aria-label={$_('nav.mainNav')}>
 			{#each navLinks as link}
 				<a href={link.href}>{link.label}</a>
 			{/each}
-			<a href="/auth/login" class="nav-login">Log in</a>
+			<a href="/auth/login" class="nav-login">{$_('nav.login')}</a>
 		</nav>
 
 		<div class="header-actions">
+			<LocaleSwitcher />
 			<ThemeSwitcher />
 			<button
 				class="hamburger desktop-hide"
-				aria-label="Toggle menu"
+				aria-label={$_('nav.toggleMenu')}
 				aria-expanded={menuOpen}
 				onclick={toggleMenu}
 			>
@@ -54,11 +57,12 @@
 	</div>
 
 	{#if menuOpen}
-		<nav class="mobile-nav" aria-label="Mobile navigation">
+		<nav class="mobile-nav" aria-label={$_('nav.mobileNav')}>
 			{#each navLinks as link}
 				<a href={link.href} onclick={() => (menuOpen = false)}>{link.label}</a>
 			{/each}
-			<a href="/auth/login" onclick={() => (menuOpen = false)}>Log in</a>
+			<a href="/auth/login" onclick={() => (menuOpen = false)}>{$_('nav.login')}</a>
+			<LocaleSwitcher />
 		</nav>
 	{/if}
 </header>

--- a/src/lib/components/LocaleSwitcher.svelte
+++ b/src/lib/components/LocaleSwitcher.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+	import { locale } from 'svelte-i18n';
+	import { browser } from '$app/environment';
+
+	let isNL = $derived($locale === 'nl-NL');
+	let isEN = $derived($locale === 'en-US');
+
+	function handleChange(newLocale: string) {
+		locale.set(newLocale);
+		if (browser) localStorage.setItem('preferredLanguage', newLocale);
+	}
+</script>
+
+<div class="language" role="radiogroup" aria-labelledby="language-switcher">
+	<p class="hidden" id="language-switcher">Choose a language for this website</p>
+	<div class="language-container-left language-container-nl" class:selected={isNL}>
+		<input
+			type="radio"
+			class="language-control"
+			id="language1-1"
+			name="language-switch1"
+			value="nl-NL"
+			checked={isNL}
+			onchange={() => handleChange('nl-NL')}
+		/>
+		<label class="language-label" for="language1-1">
+			NL<span class="hidden"> Nederlands</span>
+		</label>
+	</div>
+	<div class="language-container-right language-container-en" class:selected={isEN}>
+		<input
+			type="radio"
+			class="language-control"
+			id="language1-2"
+			name="language-switch1"
+			value="en-US"
+			checked={isEN}
+			onchange={() => handleChange('en-US')}
+		/>
+		<label class="language-label" for="language1-2">
+			EN<span class="hidden"> English</span>
+		</label>
+	</div>
+</div>
+
+<style lang="scss">
+	$language-width: 100%;
+	$language-height: 100%;
+	$language-focus: var(--pg-primary);
+	$language-border: var(--pg-input-normal);
+	$language-hover: var(--pg-soft-background);
+
+	input.language-control {
+		position: fixed;
+		opacity: 0;
+		pointer-events: none;
+	}
+
+	.hidden {
+		clip-path: inset(50%);
+		height: 1px;
+		overflow: hidden;
+		position: absolute;
+		white-space: nowrap;
+		width: 1px;
+	}
+
+	.language {
+		display: flex;
+		width: 6rem;
+		height: auto;
+		font-size: var(--pg-font-size-base);
+		line-height: 1;
+		align-content: center;
+		align-items: center;
+	}
+
+	.language-container-left,
+	.language-container-right {
+		position: relative;
+		float: left;
+		width: $language-width;
+		height: 30px;
+		padding: 0;
+	}
+
+	.language-label {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: $language-width;
+		height: $language-height;
+		border: 1px solid $language-border;
+		padding: 6px 0 2px 0;
+		background-color: transparent;
+		text-align: center;
+		text-transform: uppercase;
+		cursor: pointer;
+	}
+
+	.language-container-left .language-label {
+		border-radius: 4px 0 0 4px;
+		border-right: 1px solid $language-border;
+	}
+
+	.language-container-right .language-label {
+		border-left: 1px solid $language-border;
+		border-radius: 0 4px 4px 0;
+	}
+
+	.language-label:hover {
+		background-color: $language-hover;
+	}
+
+	.selected .language-label {
+		text-decoration: 2px underline;
+		text-decoration-color: var(--pg-text);
+		text-underline-offset: 4px;
+	}
+
+	.language-control:focus-visible + .language-label {
+		outline: 2px solid $language-focus;
+		outline-offset: 2px;
+	}
+</style>

--- a/src/lib/components/YiviLogin.svelte
+++ b/src/lib/components/YiviLogin.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _, locale } from 'svelte-i18n';
 	import '@privacybydesign/yivi-css';
 	import Icon from '@iconify/svelte';
 
@@ -34,7 +35,7 @@
 			const yivi = new YiviCore({
 				debugging: false,
 				element: '#yivi-login-container',
-				language: 'en',
+				language: $locale?.startsWith('nl') ? 'nl' : 'en',
 				minimal: true,
 				session: {
 					url: '/irma',
@@ -105,27 +106,27 @@
 	{#if status === 'idle'}
 		<button class="primary-btn yivi-btn" onclick={startYiviFlow}>
 			<Icon icon="mdi:qrcode-scan" width="20" height="20" />
-			{type === 'admin' ? 'Login as admin with Yivi' : 'Login with Yivi'}
+			{type === 'admin' ? $_('auth.yiviLoginAdmin') : $_('auth.yiviLoginOrg')}
 		</button>
 	{:else if status === 'running'}
 		<div id="yivi-login-container" class="yivi-container"></div>
 		<p class="waiting-text">
 			{#if type === 'admin'}
-				Please disclose your name, email, and phone number.
+				{$_('auth.yiviDiscloseAdmin')}
 			{:else}
-				Please disclose your organization email address.
+				{$_('auth.yiviDiscloseOrg')}
 			{/if}
 		</p>
 	{:else if status === 'success'}
 		<div class="yivi-status success">
 			<Icon icon="mdi:check-circle" width="48" height="48" />
-			<p>Authentication successful! Redirecting...</p>
+			<p>{$_('auth.yiviSuccess')}</p>
 		</div>
 	{:else if status === 'error'}
 		<div class="yivi-status error">
 			<Icon icon="mdi:alert-circle" width="32" height="32" />
 			<p>{errorMessage}</p>
-			<button class="secondary-btn" onclick={retry}>Try again</button>
+			<button class="secondary-btn" onclick={retry}>{$_('auth.tryAgain')}</button>
 		</div>
 	{/if}
 </div>

--- a/src/lib/global.scss
+++ b/src/lib/global.scss
@@ -61,8 +61,8 @@ body {
 	--pg-soft-background: #f5f3ff;
 	--pg-strong-background: #ddd6fe;
 	--pg-text: #030e17;
-	--pg-text-secondary: #5f7381;
-	--pg-input-normal: #5f7381;
+	--pg-text-secondary: #4d6070;
+	--pg-input-normal: #4d6070;
 	--pg-input-hover: #45545e;
 	--pg-input-active: #2b343b;
 	--pg-input-error: #b61616;
@@ -84,11 +84,11 @@ body {
 	--pg-soft-background: #1a1030;
 	--pg-strong-background: #2d1b69;
 	--pg-text: #ffffff;
-	--pg-text-secondary: #7e92a0;
-	--pg-input-normal: #7e92a0;
+	--pg-text-secondary: #92a3af;
+	--pg-input-normal: #92a3af;
 	--pg-input-hover: #98a8b3;
 	--pg-input-active: #c4cdd4;
-	--pg-input-error: #de3030;
+	--pg-input-error: #ef4444;
 
 	.invert {
 		filter: invert(100%);

--- a/src/lib/global.scss
+++ b/src/lib/global.scss
@@ -17,6 +17,12 @@ body {
 	text-rendering: optimizeLegibility;
 }
 
+#app {
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
+}
+
 @media (resolution: 1dppx) {
 	body {
 		-webkit-font-smoothing: subpixel-antialiased;

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,12 +1,19 @@
 import { browser } from '$app/environment';
-import { init, register } from 'svelte-i18n';
+import { register, init } from 'svelte-i18n';
 
 register('en-US', () => import('$lib/locales/en.json'));
 register('nl-NL', () => import('$lib/locales/nl.json'));
 
+const defaultLanguage = 'en-US';
+
+function getInitialLocale(): string {
+	const stored = localStorage.getItem('preferredLanguage');
+	if (stored) return stored;
+	const lang = window.navigator.language;
+	return lang.startsWith('nl') ? 'nl-NL' : 'en-US';
+}
+
 init({
-	fallbackLocale: 'en-US',
-	initialLocale: browser
-		? localStorage.getItem('preferredLanguage') ?? navigator.language
-		: 'en-US'
+	fallbackLocale: defaultLanguage,
+	initialLocale: browser ? getInitialLocale() : defaultLanguage
 });

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -9,12 +9,20 @@
 		"apiKeys": "API Keys",
 		"organization": "Organization",
 		"emailLog": "Email Log",
+		"members": "Members",
 		"dns": "DNS Verification",
-		"admin": "Admin"
+		"admin": "Admin",
+		"adminPanel": "Admin Panel",
+		"organizations": "Organizations",
+		"auditLog": "Audit Log",
+		"settings": "Settings",
+		"toggleMenu": "Toggle menu",
+		"mainNav": "Main navigation",
+		"mobileNav": "Mobile navigation"
 	},
 	"hero": {
 		"title": "Secure email signing for your organization",
-		"subtitle": "PostGuard for Business lets your organization sign and encrypt emails with identity-verified attributes. Manage API keys, verify your domain, and maintain full audit trails.",
+		"subtitle": "PostGuard for Business lets your organization sign and encrypt emails with identity-verified attributes. Manage API keys and maintain full audit trails.",
 		"cta": "Get started",
 		"pricing": "View pricing"
 	},
@@ -24,17 +32,13 @@
 			"title": "API Key Management",
 			"description": "Create and manage API keys with granular control over which organizational attributes each key signs with."
 		},
-		"dns": {
-			"title": "DNS Verification",
-			"description": "Verify your domain ownership and configure DNS records so PostGuard can sign emails on your behalf."
-		},
-		"auditLog": {
-			"title": "Email Audit Log",
-			"description": "Full audit trail of every signed email. Revoke emails, track read receipts, and export compliance reports."
-		},
 		"identity": {
 			"title": "Identity-Based Signing",
 			"description": "Sign emails with your organization name, KvK number, phone, and email — verified through Yivi."
+		},
+		"hostedEU": {
+			"title": "Hosted in the EU",
+			"description": "All data is stored and processed within the European Union, ensuring full GDPR compliance and data sovereignty."
 		},
 		"encryption": {
 			"title": "End-to-End Encryption",
@@ -43,6 +47,19 @@
 		"openSource": {
 			"title": "Open Source",
 			"description": "Built on the open-source PostGuard protocol. Full transparency, no vendor lock-in, community-driven."
+		},
+		"revocation": {
+			"title": "Email Revocation",
+			"comingSoon": "Coming soon",
+			"description": "Revoke signed emails after sending. Recipients will be notified that the email is no longer valid."
+		},
+		"dns": {
+			"title": "DNS Verification",
+			"description": "Verify your domain ownership and configure DNS records so PostGuard can sign emails on your behalf."
+		},
+		"auditLog": {
+			"title": "Email Audit Log",
+			"description": "Full audit trail of every signed email. Revoke emails, track read receipts, and export compliance reports."
 		}
 	},
 	"cta": {
@@ -51,11 +68,294 @@
 		"button": "Register your organization"
 	},
 	"footer": {
+		"brandName": "PostGuard for Business",
 		"tagline": "Enterprise-grade identity-based email signing",
 		"product": "Product",
 		"resources": "Resources",
 		"personal": "PostGuard Personal",
 		"docs": "Documentation",
-		"copyright": "© {year} PostGuard. All rights reserved."
+		"copyright": "\u00a9 {year} PostGuard. All rights reserved."
+	},
+	"seo": {
+		"siteName": "PostGuard for Business",
+		"defaultDescription": "PostGuard for Business offers enterprise-grade identity-based email signing and encryption for organizations.",
+		"homeTitle": "Enterprise Email Signing & Encryption",
+		"homeDescription": "PostGuard for Business offers enterprise-grade identity-based email signing and encryption. Manage API keys and audit email activity."
+	},
+	"pricing": {
+		"title": "Pricing",
+		"seoDescription": "Transparent per-user pricing for PostGuard for Business. Choose the plan that fits your organization.",
+		"heading": "Transparent, all-in pricing",
+		"subtitle": "Choose the plan that fits your organization.",
+		"small": {
+			"name": "Small",
+			"price": "\u20ac5\u2013\u20ac6",
+			"period": "/user/month",
+			"users": "Up to 100 users",
+			"description": "For organizations with up to 100 users.",
+			"cta": "Get started"
+		},
+		"medium": {
+			"name": "Medium",
+			"price": "\u20ac4\u2013\u20ac5",
+			"period": "/user/month",
+			"users": "Up to 300 users",
+			"description": "For growing organizations with up to 300 users.",
+			"cta": "Get started"
+		},
+		"enterprise": {
+			"name": "Enterprise",
+			"price": "Custom",
+			"users": "300+ users",
+			"description": "For large organizations with specific requirements.",
+			"cta": "Contact us"
+		},
+		"advantages": {
+			"title": "Why PostGuard for Business?",
+			"allIn": "Transparent all-in pricing",
+			"noFees": "No hidden add-on fees",
+			"onboarding": "Easy onboarding",
+			"contracts": "Flexible contracts"
+		}
+	},
+	"auth": {
+		"login": "Log in",
+		"loginSubtitle": "Authenticate with your Yivi app to access your organization portal.",
+		"loginHint": "Disclose your organization email address to log in.",
+		"noAccount": "Don't have an account?",
+		"registerOrg": "Register your organization",
+		"adminLogin": "Admin Login",
+		"adminLoginSubtitle": "Disclose your full name, email address, and phone number to log in as an administrator.",
+		"yiviLoginAdmin": "Login as admin with Yivi",
+		"yiviLoginOrg": "Login with Yivi",
+		"yiviDiscloseAdmin": "Please disclose your name, email, and phone number.",
+		"yiviDiscloseOrg": "Please disclose your organization email address.",
+		"yiviSuccess": "Authentication successful! Redirecting...",
+		"yiviFailed": "Yivi session failed. Please try again.",
+		"tryAgain": "Try again"
+	},
+	"register": {
+		"title": "Register",
+		"seoDescription": "Register your organization for PostGuard for Business.",
+		"heading": "Register your organization",
+		"subtitle": "Verify your identity with the Yivi app to register your organization for PostGuard for Business.",
+		"verifyBtn": "Verify with Yivi",
+		"yiviHint": "Please disclose your email, full name, and phone number.",
+		"submitted": "Application submitted",
+		"submittedMessage": "Thank you for registering. We will review your application and get back to you within 2 business days. You will receive a confirmation email once your organization is approved.",
+		"backHome": "Back to home",
+		"completeTitle": "Complete registration",
+		"completeSubtitle": "Your identity has been verified. Fill in the remaining details below.",
+		"fullName": "Full name",
+		"email": "Email",
+		"phone": "Phone",
+		"verifiedYivi": "Verified with Yivi",
+		"orgName": "Organization name",
+		"orgNamePlaceholder": "Acme B.V.",
+		"submit": "Submit application"
+	},
+	"dashboard": {
+		"title": "Dashboard",
+		"activeKeys": "Active API keys",
+		"emailsMonth": "Emails this month",
+		"dnsStatus": "DNS status",
+		"verified": "Verified",
+		"pending": "Pending",
+		"manage": "Manage",
+		"viewLog": "View log",
+		"configure": "Configure",
+		"quickActions": "Quick actions",
+		"createKey": "Create API key",
+		"editOrg": "Edit organization",
+		"exportLog": "Export audit log"
+	},
+	"apiKeys": {
+		"title": "API Keys",
+		"createKey": "Create key",
+		"emptyTitle": "No API keys yet",
+		"emptyDescription": "Create your first API key to start signing emails.",
+		"createApiKey": "Create API key",
+		"name": "Name",
+		"keyPrefix": "Key prefix",
+		"created": "Created",
+		"lastUsed": "Last used",
+		"expires": "Expires",
+		"never": "Never",
+		"confirm": "Confirm",
+		"cancel": "Cancel",
+		"revoke": "Revoke",
+		"create": {
+			"title": "Create API Key",
+			"created": "API key created",
+			"copyWarning": "Copy this key now. You won't be able to see it again.",
+			"backToKeys": "Back to API keys",
+			"back": "Back",
+			"keyName": "Key name",
+			"keyNamePlaceholder": "e.g. Production Mailer",
+			"keyNameHint": "A descriptive name to identify this key",
+			"expiresIn": "Expires in",
+			"days30": "30 days",
+			"days90": "90 days",
+			"days180": "180 days",
+			"year1": "1 year",
+			"signingAttrs": "Signing attributes",
+			"signingHint": "Choose which organizational attributes this API key will include when signing emails.",
+			"attrEmail": "Email address",
+			"attrOrgName": "Organization name",
+			"attrPhone": "Phone number",
+			"attrKvk": "KvK number",
+			"generate": "Generate API key",
+			"copied": "Copied!",
+			"copy": "Copy"
+		}
+	},
+	"organization": {
+		"title": "Organization",
+		"details": "Organization Details",
+		"changeSubmitted": "Change request for {fieldName} submitted. An admin will review it.",
+		"orgName": "Organization name",
+		"domain": "Domain",
+		"signingEmail": "Signing email",
+		"kvkNumber": "KvK number",
+		"contactPerson": "Contact person",
+		"requestChange": "Request change",
+		"changeRequests": "Change Requests",
+		"field": "Field",
+		"newValue": "New value",
+		"status": "Status",
+		"requested": "Requested"
+	},
+	"emailLog": {
+		"title": "Email Log",
+		"heading": "Email Audit Log",
+		"searchPlaceholder": "Search by recipient or subject...",
+		"search": "Search",
+		"emailsFound": "{count} email(s) found",
+		"noEmails": "No emails found",
+		"noSearchMatch": "No emails match your search.",
+		"noEmailsYet": "No signed emails yet. Emails will appear here once your API keys are used.",
+		"recipient": "Recipient",
+		"subject": "Subject",
+		"signed": "Signed",
+		"read": "Read",
+		"statusCol": "Status",
+		"notRead": "Not read",
+		"revoked": "Revoked",
+		"active": "Active",
+		"revoke": "Revoke",
+		"cancel": "Cancel",
+		"previous": "Previous",
+		"pageOf": "Page {page} of {totalPages}",
+		"next": "Next"
+	},
+	"dns": {
+		"title": "DNS Verification",
+		"domainVerified": "Domain verified",
+		"verificationPending": "Verification pending",
+		"verifiedOn": "Verified on {date}",
+		"verifiedSuccess": "DNS verified successfully!",
+		"instructions": "Setup Instructions",
+		"step1Title": "Add TXT record",
+		"step1Desc": "Add the following TXT record to your domain's DNS configuration:",
+		"type": "Type",
+		"nameHost": "Name/Host",
+		"value": "Value",
+		"step2Title": "Wait for propagation",
+		"step2Desc": "DNS changes can take up to 48 hours to propagate, though most changes are visible within minutes.",
+		"step3Title": "Verify",
+		"step3Desc": "Click the button below to check if your DNS records are configured correctly.",
+		"verifyBtn": "Verify DNS",
+		"lastChecked": "Last checked: {date}"
+	},
+	"members": {
+		"title": "Members",
+		"addMember": "Add member",
+		"memberAdded": "Member added successfully.",
+		"contactUpdated": "Contact person updated.",
+		"addTitle": "Add a new member",
+		"fullName": "Full name",
+		"email": "Email",
+		"phone": "Phone",
+		"optional": "(optional)",
+		"cancel": "Cancel",
+		"emptyTitle": "No members yet",
+		"emptyDescription": "Add the first member to your organization.",
+		"name": "Name",
+		"role": "Role",
+		"contactPerson": "Contact person",
+		"member": "Member",
+		"makeContact": "Make contact person",
+		"removeMember": "Remove member",
+		"remove": "Remove"
+	},
+	"admin": {
+		"impersonating": "Impersonating organization",
+		"stopImpersonating": "Stop impersonating",
+		"viewingAs": "Viewing as {orgName}",
+		"organizations": {
+			"title": "Organizations",
+			"pendingRequests": "Pending change requests ({count})",
+			"allOrgs": "All organizations",
+			"name": "Name",
+			"domain": "Domain",
+			"signingEmail": "Signing email",
+			"status": "Status",
+			"created": "Created",
+			"active": "active",
+			"pending": "pending",
+			"suspended": "suspended",
+			"activate": "Activate",
+			"suspend": "Suspend",
+			"reactivate": "Reactivate",
+			"backToOrgs": "Back to organizations",
+			"kvk": "KVK",
+			"contact": "Contact",
+			"impersonate": "Impersonate",
+			"changeRequests": "Change Requests",
+			"empty": "(empty)",
+			"validationNotes": "Validation notes (what did you check?)",
+			"approve": "Approve",
+			"reject": "Reject"
+		},
+		"apiKeys": {
+			"title": "All API Keys",
+			"keyCreated": "Key created: {rawKey}",
+			"noKeys": "No active API keys across all organizations.",
+			"organization": "Organization",
+			"keyName": "Key name",
+			"prefix": "Prefix",
+			"created": "Created",
+			"lastUsed": "Last used",
+			"never": "Never",
+			"revoke": "Revoke",
+			"confirm": "Confirm",
+			"cancel": "Cancel"
+		},
+		"auditLog": {
+			"title": "Admin Audit Log",
+			"actionsLogged": "{count} actions logged",
+			"noActions": "No admin actions logged yet.",
+			"admin": "Admin",
+			"action": "Action",
+			"target": "Target",
+			"details": "Details",
+			"ip": "IP",
+			"time": "Time",
+			"previous": "Previous",
+			"pageOf": "Page {page} of {totalPages}",
+			"next": "Next"
+		},
+		"settings": {
+			"title": "Settings",
+			"featureFlags": "Feature Flags",
+			"prodNotice": "Production mode \u2014 feature flags are set via environment variables and cannot be changed at runtime.",
+			"on": "ON",
+			"off": "OFF"
+		}
+	},
+	"common": {
+		"somethingWrong": "Something went wrong",
+		"goBack": "Go back",
+		"chooseTheme": "Choose a theme for this website"
 	}
 }

--- a/src/lib/locales/nl.json
+++ b/src/lib/locales/nl.json
@@ -9,12 +9,20 @@
 		"apiKeys": "API-sleutels",
 		"organization": "Organisatie",
 		"emailLog": "E-maillog",
+		"members": "Leden",
 		"dns": "DNS-verificatie",
-		"admin": "Beheer"
+		"admin": "Beheer",
+		"adminPanel": "Beheerpaneel",
+		"organizations": "Organisaties",
+		"auditLog": "Auditlog",
+		"settings": "Instellingen",
+		"toggleMenu": "Menu openen",
+		"mainNav": "Hoofdnavigatie",
+		"mobileNav": "Mobiele navigatie"
 	},
 	"hero": {
 		"title": "Veilige e-mailondertekening voor uw organisatie",
-		"subtitle": "PostGuard for Business laat uw organisatie e-mails ondertekenen en versleutelen met identiteitsgecontroleerde attributen. Beheer API-sleutels, verifieer uw domein en houd volledige audittrails bij.",
+		"subtitle": "PostGuard for Business laat uw organisatie e-mails ondertekenen en versleutelen met identiteitsgecontroleerde attributen. Beheer API-sleutels en houd volledige audittrails bij.",
 		"cta": "Aan de slag",
 		"pricing": "Bekijk prijzen"
 	},
@@ -24,17 +32,13 @@
 			"title": "API-sleutelbeheer",
 			"description": "Maak en beheer API-sleutels met gedetailleerde controle over welke organisatiekenmerken elke sleutel ondertekent."
 		},
-		"dns": {
-			"title": "DNS-verificatie",
-			"description": "Verifieer uw domeineigendom en configureer DNS-records zodat PostGuard e-mails namens u kan ondertekenen."
-		},
-		"auditLog": {
-			"title": "E-mail auditlog",
-			"description": "Volledige audittrail van elke ondertekende e-mail. Trek e-mails in, volg leesbevestigingen en exporteer compliancerapporten."
-		},
 		"identity": {
 			"title": "Identiteitsgebaseerde ondertekening",
-			"description": "Onderteken e-mails met uw organisatienaam, KVK-nummer, telefoonnummer en e-mailadres — geverifieerd via Yivi."
+			"description": "Onderteken e-mails met uw organisatienaam, KVK-nummer, telefoonnummer en e-mailadres \u2014 geverifieerd via Yivi."
+		},
+		"hostedEU": {
+			"title": "Gehost in de EU",
+			"description": "Alle gegevens worden opgeslagen en verwerkt binnen de Europese Unie, voor volledige AVG-naleving en datasoevereiniteit."
 		},
 		"encryption": {
 			"title": "End-to-end versleuteling",
@@ -43,6 +47,19 @@
 		"openSource": {
 			"title": "Open source",
 			"description": "Gebouwd op het open-source PostGuard-protocol. Volledige transparantie, geen vendor lock-in, community-gedreven."
+		},
+		"revocation": {
+			"title": "E-mailintrekking",
+			"comingSoon": "Binnenkort",
+			"description": "Trek ondertekende e-mails in na verzending. Ontvangers worden ge\u00efnformeerd dat de e-mail niet langer geldig is."
+		},
+		"dns": {
+			"title": "DNS-verificatie",
+			"description": "Verifieer uw domeineigendom en configureer DNS-records zodat PostGuard e-mails namens u kan ondertekenen."
+		},
+		"auditLog": {
+			"title": "E-mail auditlog",
+			"description": "Volledige audittrail van elke ondertekende e-mail. Trek e-mails in, volg leesbevestigingen en exporteer compliancerapporten."
 		}
 	},
 	"cta": {
@@ -51,11 +68,294 @@
 		"button": "Registreer uw organisatie"
 	},
 	"footer": {
+		"brandName": "PostGuard for Business",
 		"tagline": "Enterprise-grade identiteitsgebaseerde e-mailondertekening",
 		"product": "Product",
 		"resources": "Bronnen",
 		"personal": "PostGuard Persoonlijk",
 		"docs": "Documentatie",
-		"copyright": "© {year} PostGuard. Alle rechten voorbehouden."
+		"copyright": "\u00a9 {year} PostGuard. Alle rechten voorbehouden."
+	},
+	"seo": {
+		"siteName": "PostGuard for Business",
+		"defaultDescription": "PostGuard for Business biedt enterprise-grade identiteitsgebaseerde e-mailondertekening en versleuteling voor organisaties.",
+		"homeTitle": "Enterprise e-mailondertekening en versleuteling",
+		"homeDescription": "PostGuard for Business biedt enterprise-grade identiteitsgebaseerde e-mailondertekening en versleuteling. Beheer API-sleutels en controleer e-mailactiviteit."
+	},
+	"pricing": {
+		"title": "Prijzen",
+		"seoDescription": "Transparante per-gebruiker pricing voor PostGuard for Business. Kies het plan dat bij uw organisatie past.",
+		"heading": "Transparante, all-in pricing",
+		"subtitle": "Kies het plan dat bij uw organisatie past.",
+		"small": {
+			"name": "Small",
+			"price": "\u20ac5\u2013\u20ac6",
+			"period": "/gebruiker/maand",
+			"users": "Tot 100 gebruikers",
+			"description": "Voor organisaties met maximaal 100 gebruikers.",
+			"cta": "Aan de slag"
+		},
+		"medium": {
+			"name": "Medium",
+			"price": "\u20ac4\u2013\u20ac5",
+			"period": "/gebruiker/maand",
+			"users": "Tot 300 gebruikers",
+			"description": "Voor groeiende organisaties met maximaal 300 gebruikers.",
+			"cta": "Aan de slag"
+		},
+		"enterprise": {
+			"name": "Enterprise",
+			"price": "Op maat",
+			"users": "300+ gebruikers",
+			"description": "Voor grote organisaties met specifieke wensen.",
+			"cta": "Neem contact op"
+		},
+		"advantages": {
+			"title": "Waarom PostGuard for Business?",
+			"allIn": "Transparante all-in pricing",
+			"noFees": "Geen verborgen add-on fees",
+			"onboarding": "Eenvoudige onboarding",
+			"contracts": "Flexibele contracten"
+		}
+	},
+	"auth": {
+		"login": "Inloggen",
+		"loginSubtitle": "Authenticeer met uw Yivi-app om toegang te krijgen tot uw organisatieportaal.",
+		"loginHint": "Toon uw organisatie e-mailadres om in te loggen.",
+		"noAccount": "Nog geen account?",
+		"registerOrg": "Registreer uw organisatie",
+		"adminLogin": "Admin Login",
+		"adminLoginSubtitle": "Toon uw volledige naam, e-mailadres en telefoonnummer om in te loggen als beheerder.",
+		"yiviLoginAdmin": "Inloggen als admin met Yivi",
+		"yiviLoginOrg": "Inloggen met Yivi",
+		"yiviDiscloseAdmin": "Toon uw naam, e-mailadres en telefoonnummer.",
+		"yiviDiscloseOrg": "Toon uw organisatie e-mailadres.",
+		"yiviSuccess": "Authenticatie geslaagd! U wordt doorgestuurd...",
+		"yiviFailed": "Yivi-sessie mislukt. Probeer het opnieuw.",
+		"tryAgain": "Opnieuw proberen"
+	},
+	"register": {
+		"title": "Registreren",
+		"seoDescription": "Registreer uw organisatie voor PostGuard for Business.",
+		"heading": "Registreer uw organisatie",
+		"subtitle": "Verifieer uw identiteit met de Yivi-app om uw organisatie te registreren voor PostGuard for Business.",
+		"verifyBtn": "Verifi\u00ebren met Yivi",
+		"yiviHint": "Toon uw e-mailadres, volledige naam en telefoonnummer.",
+		"submitted": "Aanvraag ingediend",
+		"submittedMessage": "Bedankt voor uw registratie. We beoordelen uw aanvraag en nemen binnen 2 werkdagen contact met u op. U ontvangt een bevestigings-e-mail zodra uw organisatie is goedgekeurd.",
+		"backHome": "Terug naar home",
+		"completeTitle": "Registratie afronden",
+		"completeSubtitle": "Uw identiteit is geverifieerd. Vul de overige gegevens hieronder in.",
+		"fullName": "Volledige naam",
+		"email": "E-mailadres",
+		"phone": "Telefoonnummer",
+		"verifiedYivi": "Geverifieerd met Yivi",
+		"orgName": "Organisatienaam",
+		"orgNamePlaceholder": "Acme B.V.",
+		"submit": "Aanvraag indienen"
+	},
+	"dashboard": {
+		"title": "Dashboard",
+		"activeKeys": "Actieve API-sleutels",
+		"emailsMonth": "E-mails deze maand",
+		"dnsStatus": "DNS-status",
+		"verified": "Geverifieerd",
+		"pending": "In behandeling",
+		"manage": "Beheren",
+		"viewLog": "Log bekijken",
+		"configure": "Configureren",
+		"quickActions": "Snelle acties",
+		"createKey": "API-sleutel aanmaken",
+		"editOrg": "Organisatie bewerken",
+		"exportLog": "Auditlog exporteren"
+	},
+	"apiKeys": {
+		"title": "API-sleutels",
+		"createKey": "Sleutel aanmaken",
+		"emptyTitle": "Nog geen API-sleutels",
+		"emptyDescription": "Maak uw eerste API-sleutel aan om e-mails te ondertekenen.",
+		"createApiKey": "API-sleutel aanmaken",
+		"name": "Naam",
+		"keyPrefix": "Sleutelprefix",
+		"created": "Aangemaakt",
+		"lastUsed": "Laatst gebruikt",
+		"expires": "Verloopt",
+		"never": "Nooit",
+		"confirm": "Bevestigen",
+		"cancel": "Annuleren",
+		"revoke": "Intrekken",
+		"create": {
+			"title": "API-sleutel aanmaken",
+			"created": "API-sleutel aangemaakt",
+			"copyWarning": "Kopieer deze sleutel nu. U kunt hem daarna niet meer zien.",
+			"backToKeys": "Terug naar API-sleutels",
+			"back": "Terug",
+			"keyName": "Sleutelnaam",
+			"keyNamePlaceholder": "bijv. Productie Mailer",
+			"keyNameHint": "Een beschrijvende naam om deze sleutel te herkennen",
+			"expiresIn": "Verloopt over",
+			"days30": "30 dagen",
+			"days90": "90 dagen",
+			"days180": "180 dagen",
+			"year1": "1 jaar",
+			"signingAttrs": "Ondertekeningskenmerken",
+			"signingHint": "Kies welke organisatiekenmerken deze API-sleutel meeneemt bij het ondertekenen van e-mails.",
+			"attrEmail": "E-mailadres",
+			"attrOrgName": "Organisatienaam",
+			"attrPhone": "Telefoonnummer",
+			"attrKvk": "KVK-nummer",
+			"generate": "API-sleutel genereren",
+			"copied": "Gekopieerd!",
+			"copy": "Kopi\u00ebren"
+		}
+	},
+	"organization": {
+		"title": "Organisatie",
+		"details": "Organisatiegegevens",
+		"changeSubmitted": "Wijzigingsverzoek voor {fieldName} ingediend. Een beheerder zal het beoordelen.",
+		"orgName": "Organisatienaam",
+		"domain": "Domein",
+		"signingEmail": "Ondertekenings-e-mail",
+		"kvkNumber": "KVK-nummer",
+		"contactPerson": "Contactpersoon",
+		"requestChange": "Wijziging aanvragen",
+		"changeRequests": "Wijzigingsverzoeken",
+		"field": "Veld",
+		"newValue": "Nieuwe waarde",
+		"status": "Status",
+		"requested": "Aangevraagd"
+	},
+	"emailLog": {
+		"title": "E-maillog",
+		"heading": "E-mail auditlog",
+		"searchPlaceholder": "Zoek op ontvanger of onderwerp...",
+		"search": "Zoeken",
+		"emailsFound": "{count} e-mail(s) gevonden",
+		"noEmails": "Geen e-mails gevonden",
+		"noSearchMatch": "Geen e-mails komen overeen met uw zoekopdracht.",
+		"noEmailsYet": "Nog geen ondertekende e-mails. E-mails verschijnen hier zodra uw API-sleutels worden gebruikt.",
+		"recipient": "Ontvanger",
+		"subject": "Onderwerp",
+		"signed": "Ondertekend",
+		"read": "Gelezen",
+		"statusCol": "Status",
+		"notRead": "Niet gelezen",
+		"revoked": "Ingetrokken",
+		"active": "Actief",
+		"revoke": "Intrekken",
+		"cancel": "Annuleren",
+		"previous": "Vorige",
+		"pageOf": "Pagina {page} van {totalPages}",
+		"next": "Volgende"
+	},
+	"dns": {
+		"title": "DNS-verificatie",
+		"domainVerified": "Domein geverifieerd",
+		"verificationPending": "Verificatie in behandeling",
+		"verifiedOn": "Geverifieerd op {date}",
+		"verifiedSuccess": "DNS succesvol geverifieerd!",
+		"instructions": "Installatie-instructies",
+		"step1Title": "TXT-record toevoegen",
+		"step1Desc": "Voeg het volgende TXT-record toe aan de DNS-configuratie van uw domein:",
+		"type": "Type",
+		"nameHost": "Naam/Host",
+		"value": "Waarde",
+		"step2Title": "Wacht op propagatie",
+		"step2Desc": "DNS-wijzigingen kunnen tot 48 uur duren om te propageren, hoewel de meeste wijzigingen binnen enkele minuten zichtbaar zijn.",
+		"step3Title": "Verifi\u00ebren",
+		"step3Desc": "Klik op de knop hieronder om te controleren of uw DNS-records correct zijn geconfigureerd.",
+		"verifyBtn": "DNS verifi\u00ebren",
+		"lastChecked": "Laatst gecontroleerd: {date}"
+	},
+	"members": {
+		"title": "Leden",
+		"addMember": "Lid toevoegen",
+		"memberAdded": "Lid succesvol toegevoegd.",
+		"contactUpdated": "Contactpersoon bijgewerkt.",
+		"addTitle": "Nieuw lid toevoegen",
+		"fullName": "Volledige naam",
+		"email": "E-mailadres",
+		"phone": "Telefoonnummer",
+		"optional": "(optioneel)",
+		"cancel": "Annuleren",
+		"emptyTitle": "Nog geen leden",
+		"emptyDescription": "Voeg het eerste lid toe aan uw organisatie.",
+		"name": "Naam",
+		"role": "Rol",
+		"contactPerson": "Contactpersoon",
+		"member": "Lid",
+		"makeContact": "Maak contactpersoon",
+		"removeMember": "Lid verwijderen",
+		"remove": "Verwijderen"
+	},
+	"admin": {
+		"impersonating": "Organisatie nagebootst",
+		"stopImpersonating": "Stop nabootsen",
+		"viewingAs": "Bekijkt als {orgName}",
+		"organizations": {
+			"title": "Organisaties",
+			"pendingRequests": "Openstaande wijzigingsverzoeken ({count})",
+			"allOrgs": "Alle organisaties",
+			"name": "Naam",
+			"domain": "Domein",
+			"signingEmail": "Ondertekenings-e-mail",
+			"status": "Status",
+			"created": "Aangemaakt",
+			"active": "actief",
+			"pending": "in behandeling",
+			"suspended": "opgeschort",
+			"activate": "Activeren",
+			"suspend": "Opschorten",
+			"reactivate": "Heractiveren",
+			"backToOrgs": "Terug naar organisaties",
+			"kvk": "KVK",
+			"contact": "Contact",
+			"impersonate": "Nabootsen",
+			"changeRequests": "Wijzigingsverzoeken",
+			"empty": "(leeg)",
+			"validationNotes": "Validatienotities (wat heeft u gecontroleerd?)",
+			"approve": "Goedkeuren",
+			"reject": "Afwijzen"
+		},
+		"apiKeys": {
+			"title": "Alle API-sleutels",
+			"keyCreated": "Sleutel aangemaakt: {rawKey}",
+			"noKeys": "Geen actieve API-sleutels bij alle organisaties.",
+			"organization": "Organisatie",
+			"keyName": "Sleutelnaam",
+			"prefix": "Prefix",
+			"created": "Aangemaakt",
+			"lastUsed": "Laatst gebruikt",
+			"never": "Nooit",
+			"revoke": "Intrekken",
+			"confirm": "Bevestigen",
+			"cancel": "Annuleren"
+		},
+		"auditLog": {
+			"title": "Admin auditlog",
+			"actionsLogged": "{count} acties gelogd",
+			"noActions": "Nog geen admin-acties gelogd.",
+			"admin": "Admin",
+			"action": "Actie",
+			"target": "Doel",
+			"details": "Details",
+			"ip": "IP",
+			"time": "Tijd",
+			"previous": "Vorige",
+			"pageOf": "Pagina {page} van {totalPages}",
+			"next": "Volgende"
+		},
+		"settings": {
+			"title": "Instellingen",
+			"featureFlags": "Functieschakelaars",
+			"prodNotice": "Productiemodus \u2014 functieschakelaars worden ingesteld via omgevingsvariabelen en kunnen niet tijdens runtime worden gewijzigd.",
+			"on": "AAN",
+			"off": "UIT"
+		}
+	},
+	"common": {
+		"somethingWrong": "Er is iets misgegaan",
+		"goBack": "Ga terug",
+		"chooseTheme": "Kies een thema voor deze website"
 	}
 }

--- a/src/routes/(admin)/+layout.svelte
+++ b/src/routes/(admin)/+layout.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import Icon from '@iconify/svelte';
 	import logoLight from '$lib/assets/images/logo.svg';
 	import logoDark from '$lib/assets/images/logo-dark.svg';
 	import ThemeSwitcher from '$lib/components/ThemeSwitcher.svelte';
+	import LocaleSwitcher from '$lib/components/LocaleSwitcher.svelte';
 	import type { LayoutData } from './$types';
 
 	let { data, children }: { data: LayoutData; children: import('svelte').Snippet } = $props();
@@ -11,23 +13,23 @@
 	const navItems = $derived([
 		...(data.adminPanelEnabled
 			? [
-					{ href: '/admin/organizations', label: 'Organizations', icon: 'mdi:domain' },
-					{ href: '/admin/api-keys', label: 'API Keys', icon: 'mdi:key-variant' }
+					{ href: '/admin/organizations', label: $_('nav.organizations'), icon: 'mdi:domain' },
+					{ href: '/admin/api-keys', label: $_('nav.apiKeys'), icon: 'mdi:key-variant' }
 				]
 			: []),
 		...(data.adminPanelEnabled && data.adminAuditLogEnabled
-			? [{ href: '/admin/audit-log', label: 'Audit Log', icon: 'mdi:clipboard-text-clock' }]
+			? [{ href: '/admin/audit-log', label: $_('nav.auditLog'), icon: 'mdi:clipboard-text-clock' }]
 			: []),
-		{ href: '/admin/settings', label: 'Settings', icon: 'mdi:cog' }
+		{ href: '/admin/settings', label: $_('nav.settings'), icon: 'mdi:cog' }
 	]);
 </script>
 
 {#if data.impersonatingOrgId}
 	<div class="impersonation-bar">
 		<Icon icon="mdi:eye" width="16" height="16" />
-		<span>Impersonating organization</span>
+		<span>{$_('admin.impersonating')}</span>
 		<form method="POST" action="/api/admin/impersonate/stop">
-			<button type="submit" class="stop-btn">Stop impersonating</button>
+			<button type="submit" class="stop-btn">{$_('admin.stopImpersonating')}</button>
 		</form>
 	</div>
 {/if}
@@ -62,7 +64,7 @@
 			<form method="POST" action="/auth/logout">
 				<button type="submit" class="nav-item logout-btn">
 					<Icon icon="mdi:logout" width="20" height="20" />
-					<span>Log out</span>
+					<span>{$_('nav.logout')}</span>
 				</button>
 			</form>
 		</div>
@@ -73,8 +75,9 @@
 			<button class="hamburger desktop-hide" onclick={() => (sidebarOpen = true)}>
 				<Icon icon="mdi:menu" width="24" height="24" />
 			</button>
-			<h2 class="header-title">Admin Panel</h2>
+			<h2 class="header-title">{$_('nav.adminPanel')}</h2>
 			<div class="header-actions">
+				<LocaleSwitcher />
 				<ThemeSwitcher />
 			</div>
 		</header>

--- a/src/routes/(admin)/admin/api-keys/+page.svelte
+++ b/src/routes/(admin)/admin/api-keys/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import SEO from '$lib/components/SEO.svelte';
 	import Icon from '@iconify/svelte';
 	import { enhance } from '$app/forms';
@@ -8,29 +9,29 @@
 	let confirmRevoke = $state<string | null>(null);
 </script>
 
-<SEO title="API Keys - Admin" />
+<SEO title="{$_('admin.apiKeys.title')} - Admin" />
 
-<h1>All API Keys</h1>
+<h1>{$_('admin.apiKeys.title')}</h1>
 
 {#if form?.created && form?.rawKey}
 	<div class="key-banner">
 		<Icon icon="mdi:key-chain" width="20" height="20" />
-		<span>Key created: <code>{form.rawKey}</code></span>
+		<span>{$_('admin.apiKeys.keyCreated', { values: { rawKey: form.rawKey } })}</span>
 	</div>
 {/if}
 
 {#if data.keys.length === 0}
-	<p class="empty">No active API keys across all organizations.</p>
+	<p class="empty">{$_('admin.apiKeys.noKeys')}</p>
 {:else}
 	<div class="table-wrapper">
 		<table>
 			<thead>
 				<tr>
-					<th>Organization</th>
-					<th>Key name</th>
-					<th>Prefix</th>
-					<th>Created</th>
-					<th>Last used</th>
+					<th>{$_('admin.apiKeys.organization')}</th>
+					<th>{$_('admin.apiKeys.keyName')}</th>
+					<th>{$_('admin.apiKeys.prefix')}</th>
+					<th>{$_('admin.apiKeys.created')}</th>
+					<th>{$_('admin.apiKeys.lastUsed')}</th>
 					<th></th>
 				</tr>
 			</thead>
@@ -45,7 +46,7 @@
 							{#if item.key.lastUsedAt}
 								{new Date(item.key.lastUsedAt).toLocaleDateString()}
 							{:else}
-								<span class="muted">Never</span>
+								<span class="muted">{$_('admin.apiKeys.never')}</span>
 							{/if}
 						</td>
 						<td>
@@ -53,14 +54,14 @@
 								<form method="POST" action="?/revoke" use:enhance>
 									<input type="hidden" name="keyId" value={item.key.id} />
 									<div class="confirm-row">
-										<button type="submit" class="danger-btn">Confirm</button>
-										<button type="button" class="ghost-btn" onclick={() => (confirmRevoke = null)}>Cancel</button>
+										<button type="submit" class="danger-btn">{$_('admin.apiKeys.confirm')}</button>
+										<button type="button" class="ghost-btn" onclick={() => (confirmRevoke = null)}>{$_('admin.apiKeys.cancel')}</button>
 									</div>
 								</form>
 							{:else}
 								<button class="ghost-btn danger" onclick={() => (confirmRevoke = item.key.id)}>
 									<Icon icon="mdi:delete" width="16" height="16" />
-									Revoke
+									{$_('admin.apiKeys.revoke')}
 								</button>
 							{/if}
 						</td>

--- a/src/routes/(admin)/admin/audit-log/+page.svelte
+++ b/src/routes/(admin)/admin/audit-log/+page.svelte
@@ -1,28 +1,29 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import SEO from '$lib/components/SEO.svelte';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
 </script>
 
-<SEO title="Audit Log - Admin" />
+<SEO title="{$_('admin.auditLog.title')} - Admin" />
 
-<h1>Admin Audit Log</h1>
-<p class="subtitle">{data.auditLog.total} actions logged</p>
+<h1>{$_('admin.auditLog.title')}</h1>
+<p class="subtitle">{$_('admin.auditLog.actionsLogged', { values: { count: data.auditLog.total } })}</p>
 
 {#if data.auditLog.logs.length === 0}
-	<p class="empty">No admin actions logged yet.</p>
+	<p class="empty">{$_('admin.auditLog.noActions')}</p>
 {:else}
 	<div class="table-wrapper">
 		<table>
 			<thead>
 				<tr>
-					<th>Admin</th>
-					<th>Action</th>
-					<th>Target</th>
-					<th>Details</th>
-					<th>IP</th>
-					<th>Time</th>
+					<th>{$_('admin.auditLog.admin')}</th>
+					<th>{$_('admin.auditLog.action')}</th>
+					<th>{$_('admin.auditLog.target')}</th>
+					<th>{$_('admin.auditLog.details')}</th>
+					<th>{$_('admin.auditLog.ip')}</th>
+					<th>{$_('admin.auditLog.time')}</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -55,11 +56,11 @@
 	{#if data.auditLog.totalPages > 1}
 		<div class="pagination">
 			{#if data.auditLog.page > 1}
-				<a href="/admin/audit-log?page={data.auditLog.page - 1}" class="secondary-btn">Previous</a>
+				<a href="/admin/audit-log?page={data.auditLog.page - 1}" class="secondary-btn">{$_('admin.auditLog.previous')}</a>
 			{/if}
-			<span class="page-info">Page {data.auditLog.page} of {data.auditLog.totalPages}</span>
+			<span class="page-info">{$_('admin.auditLog.pageOf', { values: { page: data.auditLog.page, totalPages: data.auditLog.totalPages } })}</span>
 			{#if data.auditLog.page < data.auditLog.totalPages}
-				<a href="/admin/audit-log?page={data.auditLog.page + 1}" class="secondary-btn">Next</a>
+				<a href="/admin/audit-log?page={data.auditLog.page + 1}" class="secondary-btn">{$_('admin.auditLog.next')}</a>
 			{/if}
 		</div>
 	{/if}

--- a/src/routes/(admin)/admin/organizations/+page.svelte
+++ b/src/routes/(admin)/admin/organizations/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import SEO from '$lib/components/SEO.svelte';
 	import Icon from '@iconify/svelte';
 	import { enhance } from '$app/forms';
@@ -7,15 +8,15 @@
 	let { data }: { data: PageData } = $props();
 </script>
 
-<SEO title="Organizations - Admin" />
+<SEO title="{$_('admin.organizations.title')} - Admin" />
 
-<h1>Organizations</h1>
+<h1>{$_('admin.organizations.title')}</h1>
 
 {#if data.pendingRequests.length > 0}
 	<section class="pending-section">
 		<h2>
 			<Icon icon="mdi:bell-ring" width="20" height="20" />
-			Pending change requests ({data.pendingRequests.length})
+			{$_('admin.organizations.pendingRequests', { values: { count: data.pendingRequests.length } })}
 		</h2>
 		<div class="pending-list">
 			{#each data.pendingRequests as item}
@@ -32,16 +33,16 @@
 {/if}
 
 <section>
-	<h2>All organizations</h2>
+	<h2>{$_('admin.organizations.allOrgs')}</h2>
 	<div class="table-wrapper">
 		<table>
 			<thead>
 				<tr>
-					<th>Name</th>
-					<th>Domain</th>
-					<th>Signing email</th>
-					{#if data.orgStatusEnabled}<th>Status</th>{/if}
-					<th>Created</th>
+					<th>{$_('admin.organizations.name')}</th>
+					<th>{$_('admin.organizations.domain')}</th>
+					<th>{$_('admin.organizations.signingEmail')}</th>
+					{#if data.orgStatusEnabled}<th>{$_('admin.organizations.status')}</th>{/if}
+					<th>{$_('admin.organizations.created')}</th>
 					{#if data.orgStatusEnabled}<th></th>{/if}
 				</tr>
 			</thead>
@@ -54,7 +55,7 @@
 						{#if data.orgStatusEnabled}
 							<td>
 								<span class="status" class:active={org.status === 'active'} class:pending={org.status === 'pending'} class:suspended={org.status === 'suspended'}>
-									{org.status}
+									{$_(`admin.organizations.${org.status}`)}
 								</span>
 							</td>
 						{/if}
@@ -64,17 +65,17 @@
 								{#if org.status === 'pending'}
 									<form method="POST" action="?/activate" use:enhance>
 										<input type="hidden" name="orgId" value={org.id} />
-										<button type="submit" class="action-btn approve">Activate</button>
+										<button type="submit" class="action-btn approve">{$_('admin.organizations.activate')}</button>
 									</form>
 								{:else if org.status === 'active'}
 									<form method="POST" action="?/suspend" use:enhance>
 										<input type="hidden" name="orgId" value={org.id} />
-										<button type="submit" class="action-btn suspend">Suspend</button>
+										<button type="submit" class="action-btn suspend">{$_('admin.organizations.suspend')}</button>
 									</form>
 								{:else}
 									<form method="POST" action="?/activate" use:enhance>
 										<input type="hidden" name="orgId" value={org.id} />
-										<button type="submit" class="action-btn approve">Reactivate</button>
+										<button type="submit" class="action-btn approve">{$_('admin.organizations.reactivate')}</button>
 									</form>
 								{/if}
 							</td>

--- a/src/routes/(admin)/admin/organizations/[id]/+page.svelte
+++ b/src/routes/(admin)/admin/organizations/[id]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import SEO from '$lib/components/SEO.svelte';
 	import Icon from '@iconify/svelte';
 	import { enhance } from '$app/forms';
@@ -12,7 +13,7 @@
 
 <a href="/admin/organizations" class="back-link">
 	<Icon icon="mdi:arrow-left" width="16" height="16" />
-	Back to organizations
+	{$_('admin.organizations.backToOrgs')}
 </a>
 
 <div class="org-header">
@@ -23,10 +24,10 @@
 </div>
 
 <div class="org-details">
-	<div class="detail"><span class="label">Domain</span><span>{data.organization.domain}</span></div>
-	<div class="detail"><span class="label">Signing email</span><span>{data.organization.signingEmail}</span></div>
-	<div class="detail"><span class="label">KVK</span><span>{data.organization.kvkNumber ?? '—'}</span></div>
-	<div class="detail"><span class="label">Contact</span><span>{data.contactPerson ? `${data.contactPerson.fullName} (${data.contactPerson.email})` : '—'}</span></div>
+	<div class="detail"><span class="label">{$_('admin.organizations.domain')}</span><span>{data.organization.domain}</span></div>
+	<div class="detail"><span class="label">{$_('admin.organizations.signingEmail')}</span><span>{data.organization.signingEmail}</span></div>
+	<div class="detail"><span class="label">{$_('admin.organizations.kvk')}</span><span>{data.organization.kvkNumber ?? '—'}</span></div>
+	<div class="detail"><span class="label">{$_('admin.organizations.contact')}</span><span>{data.contactPerson ? `${data.contactPerson.fullName} (${data.contactPerson.email})` : '—'}</span></div>
 </div>
 
 {#if data.impersonationEnabled}
@@ -34,7 +35,7 @@
 		<form method="POST" action="?/impersonate" use:enhance>
 			<button type="submit" class="secondary-btn">
 				<Icon icon="mdi:eye" width="16" height="16" />
-				Impersonate
+				{$_('admin.organizations.impersonate')}
 			</button>
 		</form>
 	</div>
@@ -42,7 +43,7 @@
 
 {#if data.requests.length > 0}
 	<section class="requests">
-		<h2>Change Requests</h2>
+		<h2>{$_('admin.organizations.changeRequests')}</h2>
 		{#each data.requests as req}
 			<div class="request-card" class:pending={req.status === 'pending'}>
 				<div class="request-header">
@@ -52,7 +53,7 @@
 					</span>
 				</div>
 				<div class="req-values">
-					<span class="old">{req.oldValue ?? '(empty)'}</span>
+					<span class="old">{req.oldValue ?? $_('admin.organizations.empty')}</span>
 					<Icon icon="mdi:arrow-right" width="14" height="14" />
 					<span class="new">{req.newValue}</span>
 				</div>
@@ -63,19 +64,19 @@
 						<input
 							type="text"
 							class="pg-input"
-							placeholder="Validation notes (what did you check?)"
+							placeholder={$_('admin.organizations.validationNotes')}
 							bind:value={reviewNotes}
 						/>
 						<div class="review-actions">
 							<form method="POST" action="?/approve" use:enhance>
 								<input type="hidden" name="requestId" value={req.id} />
 								<input type="hidden" name="reviewNotes" value={reviewNotes} />
-								<button type="submit" class="action-btn approve">Approve</button>
+								<button type="submit" class="action-btn approve">{$_('admin.organizations.approve')}</button>
 							</form>
 							<form method="POST" action="?/reject" use:enhance>
 								<input type="hidden" name="requestId" value={req.id} />
 								<input type="hidden" name="reviewNotes" value={reviewNotes} />
-								<button type="submit" class="action-btn reject">Reject</button>
+								<button type="submit" class="action-btn reject">{$_('admin.organizations.reject')}</button>
 							</form>
 						</div>
 					</div>

--- a/src/routes/(admin)/admin/settings/+page.svelte
+++ b/src/routes/(admin)/admin/settings/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import SEO from '$lib/components/SEO.svelte';
 	import Icon from '@iconify/svelte';
 	import type { PageData } from './$types';
@@ -24,17 +25,17 @@
 
 </script>
 
-<SEO title="Settings - Admin" />
+<SEO title="{$_('admin.settings.title')} - Admin" />
 
-<h1>Settings</h1>
+<h1>{$_('admin.settings.title')}</h1>
 
 <section class="flags-section">
-	<h2>Feature Flags</h2>
+	<h2>{$_('admin.settings.featureFlags')}</h2>
 
 	{#if !data.canToggle}
 		<div class="prod-notice">
 			<Icon icon="mdi:lock" width="18" height="18" />
-			<span>Production mode — feature flags are set via environment variables and cannot be changed at runtime.</span>
+			<span>{$_('admin.settings.prodNotice')}</span>
 		</div>
 	{/if}
 
@@ -53,7 +54,7 @@
 						disabled={!data.canToggle || updating === flag}
 						onclick={() => toggleFlag(flag, info.value)}
 					>
-						{info.value ? 'ON' : 'OFF'}
+						{info.value ? $_('admin.settings.on') : $_('admin.settings.off')}
 					</button>
 					</div>
 			</div>

--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import SEO from '$lib/components/SEO.svelte';
 	import Icon from '@iconify/svelte';
 	import type { PageData } from './$types';
@@ -7,38 +8,35 @@
 </script>
 
 <SEO
-	title="Enterprise Email Signing & Encryption"
-	description="PostGuard for Business offers enterprise-grade identity-based email signing and encryption. Manage API keys, verify domains, and audit email activity."
+	title={$_('seo.homeTitle')}
+	description={$_('seo.homeDescription')}
 />
 
 <section class="hero">
 	<div class="hero-content">
-		<h1>Secure email signing for your organization</h1>
+		<h1>{$_('hero.title')}</h1>
 		<p class="hero-subtitle">
-			PostGuard for Business lets your organization sign and encrypt emails with
-			identity-verified attributes. Manage API keys, verify your domain, and maintain full
-			audit trails.
+			{$_('hero.subtitle')}
 		</p>
 		<div class="hero-actions">
-			<a href="/register" class="primary-btn">Get started</a>
+			<a href="/register" class="primary-btn">{$_('hero.cta')}</a>
 			{#if data.marketingFlags.pricing}
-				<a href="/pricing" class="secondary-btn">View pricing</a>
+				<a href="/pricing" class="secondary-btn">{$_('hero.pricing')}</a>
 			{/if}
 		</div>
 	</div>
 </section>
 
 <section class="features">
-	<h2 class="section-title">Why PostGuard for Business?</h2>
+	<h2 class="section-title">{$_('features.title')}</h2>
 	<div class="features-grid">
 		<div class="feature-card">
 			<div class="feature-icon">
 				<Icon icon="mdi:key-variant" width="32" height="32" />
 			</div>
-			<h3>API Key Management</h3>
+			<h3>{$_('features.apiKeys.title')}</h3>
 			<p>
-				Create and manage API keys with granular control over which organizational attributes
-				each key signs with.
+				{$_('features.apiKeys.description')}
 			</p>
 		</div>
 
@@ -46,10 +44,9 @@
 			<div class="feature-icon">
 				<Icon icon="mdi:shield-account" width="32" height="32" />
 			</div>
-			<h3>Identity-Based Signing</h3>
+			<h3>{$_('features.identity.title')}</h3>
 			<p>
-				Sign emails with your organization name, KvK number, phone, and email — verified
-				through Yivi.
+				{$_('features.identity.description')}
 			</p>
 		</div>
 
@@ -57,10 +54,9 @@
 			<div class="feature-icon">
 				<Icon icon="mdi:server-security" width="32" height="32" />
 			</div>
-			<h3>Hosted in the EU</h3>
+			<h3>{$_('features.hostedEU.title')}</h3>
 			<p>
-				All data is stored and processed within the European Union, ensuring full GDPR
-				compliance and data sovereignty.
+				{$_('features.hostedEU.description')}
 			</p>
 		</div>
 
@@ -68,10 +64,9 @@
 			<div class="feature-icon">
 				<Icon icon="mdi:lock-check" width="32" height="32" />
 			</div>
-			<h3>End-to-End Encryption</h3>
+			<h3>{$_('features.encryption.title')}</h3>
 			<p>
-				Emails are encrypted end-to-end. Only the intended recipient with the right identity
-				attributes can decrypt.
+				{$_('features.encryption.description')}
 			</p>
 		</div>
 
@@ -79,10 +74,9 @@
 			<div class="feature-icon">
 				<Icon icon="mdi:source-branch" width="32" height="32" />
 			</div>
-			<h3>Open Source</h3>
+			<h3>{$_('features.openSource.title')}</h3>
 			<p>
-				Built on the open-source PostGuard protocol. Full transparency, no vendor lock-in,
-				community-driven.
+				{$_('features.openSource.description')}
 			</p>
 		</div>
 
@@ -90,10 +84,9 @@
 			<div class="feature-icon">
 				<Icon icon="mdi:email-remove" width="32" height="32" />
 			</div>
-			<h3>Email Revocation <span class="coming-soon">Coming soon</span></h3>
+			<h3>{$_('features.revocation.title')} <span class="coming-soon">{$_('features.revocation.comingSoon')}</span></h3>
 			<p>
-				Revoke signed emails after sending. Recipients will be notified that the email is
-				no longer valid.
+				{$_('features.revocation.description')}
 			</p>
 		</div>
 	</div>
@@ -101,9 +94,9 @@
 
 <section class="cta">
 	<div class="cta-content">
-		<h2>Ready to secure your organization's email?</h2>
-		<p>Register for PostGuard for Business and start signing emails in minutes.</p>
-		<a href="/register" class="primary-btn">Register your organization</a>
+		<h2>{$_('cta.title')}</h2>
+		<p>{$_('cta.subtitle')}</p>
+		<a href="/register" class="primary-btn">{$_('cta.button')}</a>
 	</div>
 </section>
 

--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -48,43 +48,41 @@
 <section class="features">
 	<h2 class="section-title">{$_('features.title')}</h2>
 
-	<div class="feature-rows">
-		<div class="feature-row highlight-row">
-			<div class="row-icon"><Icon icon="mdi:key-variant" width="36" height="36" /></div>
-			<div class="row-body">
-				<h3>{$_('features.apiKeys.title')}</h3>
-				<p>{$_('features.apiKeys.description')}</p>
-			</div>
+	<div class="feature-list">
+		<div class="feature-block">
+			<div class="bg-icon"><Icon icon="mdi:key-variant" width="120" height="120" /></div>
+			<h3>{$_('features.apiKeys.title')}</h3>
+			<p>{$_('features.apiKeys.description')}</p>
 		</div>
 
-		<div class="feature-pair">
-			<div class="bento-item">
-				<h3><Icon icon="mdi:shield-account" width="20" height="20" />{$_('features.identity.title')}</h3>
-				<p>{$_('features.identity.description')}</p>
-			</div>
-			<div class="bento-item">
-				<h3><Icon icon="mdi:lock-check" width="20" height="20" />{$_('features.encryption.title')}</h3>
-				<p>{$_('features.encryption.description')}</p>
-			</div>
+		<div class="feature-block">
+			<div class="bg-icon"><Icon icon="mdi:shield-account" width="120" height="120" /></div>
+			<h3>{$_('features.identity.title')}</h3>
+			<p>{$_('features.identity.description')}</p>
 		</div>
 
-		<div class="feature-row">
-			<div class="row-icon"><Icon icon="mdi:server-security" width="36" height="36" /></div>
-			<div class="row-body">
-				<h3>{$_('features.hostedEU.title')}</h3>
-				<p>{$_('features.hostedEU.description')}</p>
-			</div>
+		<div class="feature-block">
+			<div class="bg-icon"><Icon icon="mdi:lock-check" width="120" height="120" /></div>
+			<h3>{$_('features.encryption.title')}</h3>
+			<p>{$_('features.encryption.description')}</p>
 		</div>
 
-		<div class="feature-pair">
-			<div class="bento-item">
-				<h3><Icon icon="mdi:source-branch" width="20" height="20" />{$_('features.openSource.title')}</h3>
-				<p>{$_('features.openSource.description')}</p>
-			</div>
-			<div class="bento-item muted">
-				<h3><Icon icon="mdi:email-remove" width="20" height="20" />{$_('features.revocation.title')} <span class="coming-soon">{$_('features.revocation.comingSoon')}</span></h3>
-				<p>{$_('features.revocation.description')}</p>
-			</div>
+		<div class="feature-block">
+			<div class="bg-icon"><Icon icon="mdi:server-security" width="120" height="120" /></div>
+			<h3>{$_('features.hostedEU.title')}</h3>
+			<p>{$_('features.hostedEU.description')}</p>
+		</div>
+
+		<div class="feature-block">
+			<div class="bg-icon"><Icon icon="mdi:source-branch" width="120" height="120" /></div>
+			<h3>{$_('features.openSource.title')}</h3>
+			<p>{$_('features.openSource.description')}</p>
+		</div>
+
+		<div class="feature-block muted">
+			<div class="bg-icon"><Icon icon="mdi:email-remove" width="120" height="120" /></div>
+			<h3>{$_('features.revocation.title')} <span class="coming-soon">{$_('features.revocation.comingSoon')}</span></h3>
+			<p>{$_('features.revocation.description')}</p>
 		</div>
 	</div>
 </section>
@@ -203,87 +201,53 @@
 		margin-bottom: 2rem;
 	}
 
-	.feature-rows {
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-	}
-
-	/* Full-width horizontal feature row */
-	.feature-row {
-		display: flex;
-		align-items: flex-start;
-		gap: 1.5rem;
-		padding: 1.75rem;
-		border: 1px solid var(--pg-strong-background);
-		border-radius: var(--pg-border-radius-lg);
-
-		&.highlight-row {
-			background: var(--pg-soft-background);
-			border: none;
-		}
-
-		@media only screen and (max-width: 600px) {
-			flex-direction: column;
-			gap: 0.75rem;
-		}
-	}
-
-	.row-icon {
-		color: var(--pg-primary);
-		flex-shrink: 0;
-		padding-top: 0.15rem;
-	}
-
-	.row-body {
-		h3 {
-			margin: 0 0 0.35rem;
-		}
-
-		p {
-			color: var(--pg-text-secondary);
-			font-size: var(--pg-font-size-md);
-			line-height: 1.5;
-			max-width: 600px;
-		}
-	}
-
-	/* Side-by-side compact pair */
-	.feature-pair {
+	.feature-list {
 		display: grid;
 		grid-template-columns: 1fr 1fr;
 		gap: 1rem;
 
-		@media only screen and (max-width: 600px) {
+		@media only screen and (max-width: 700px) {
 			grid-template-columns: 1fr;
 		}
 	}
 
-	.bento-item {
-		background: var(--pg-soft-background);
+	.feature-block {
+		position: relative;
+		overflow: hidden;
 		border-radius: var(--pg-border-radius-lg);
-		padding: 1.25rem;
+		padding: 2rem 1.75rem;
+		min-height: 160px;
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-end;
+		background: var(--pg-soft-background);
 
 		&.muted {
-			opacity: 0.65;
+			opacity: 0.6;
 		}
 
 		h3 {
-			display: flex;
-			align-items: center;
-			gap: 0.5rem;
+			position: relative;
 			margin: 0 0 0.35rem;
-
-			:global(svg) {
-				color: var(--pg-primary);
-				flex-shrink: 0;
-			}
 		}
 
 		p {
+			position: relative;
 			color: var(--pg-text-secondary);
 			font-size: var(--pg-font-size-md);
 			line-height: 1.5;
+		}
+	}
+
+	.bg-icon {
+		position: absolute;
+		top: -10px;
+		right: -10px;
+		opacity: 0.08;
+		pointer-events: none;
+
+		:global(svg) {
+			color: var(--pg-primary);
 		}
 	}
 

--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -50,38 +50,32 @@
 
 	<div class="bento">
 		<div class="bento-item wide">
-			<div class="bento-icon"><Icon icon="mdi:key-variant" width="28" height="28" /></div>
-			<h3>{$_('features.apiKeys.title')}</h3>
+			<h3><Icon icon="mdi:key-variant" width="20" height="20" />{$_('features.apiKeys.title')}</h3>
 			<p>{$_('features.apiKeys.description')}</p>
 		</div>
 
 		<div class="bento-item">
-			<div class="bento-icon"><Icon icon="mdi:shield-account" width="28" height="28" /></div>
-			<h3>{$_('features.identity.title')}</h3>
+			<h3><Icon icon="mdi:shield-account" width="20" height="20" />{$_('features.identity.title')}</h3>
 			<p>{$_('features.identity.description')}</p>
 		</div>
 
 		<div class="bento-item">
-			<div class="bento-icon"><Icon icon="mdi:server-security" width="28" height="28" /></div>
-			<h3>{$_('features.hostedEU.title')}</h3>
+			<h3><Icon icon="mdi:server-security" width="20" height="20" />{$_('features.hostedEU.title')}</h3>
 			<p>{$_('features.hostedEU.description')}</p>
 		</div>
 
 		<div class="bento-item">
-			<div class="bento-icon"><Icon icon="mdi:lock-check" width="28" height="28" /></div>
-			<h3>{$_('features.encryption.title')}</h3>
+			<h3><Icon icon="mdi:lock-check" width="20" height="20" />{$_('features.encryption.title')}</h3>
 			<p>{$_('features.encryption.description')}</p>
 		</div>
 
 		<div class="bento-item wide">
-			<div class="bento-icon"><Icon icon="mdi:source-branch" width="28" height="28" /></div>
-			<h3>{$_('features.openSource.title')}</h3>
+			<h3><Icon icon="mdi:source-branch" width="20" height="20" />{$_('features.openSource.title')}</h3>
 			<p>{$_('features.openSource.description')}</p>
 		</div>
 
 		<div class="bento-item muted">
-			<div class="bento-icon"><Icon icon="mdi:email-remove" width="28" height="28" /></div>
-			<h3>{$_('features.revocation.title')} <span class="coming-soon">{$_('features.revocation.comingSoon')}</span></h3>
+			<h3><Icon icon="mdi:email-remove" width="20" height="20" />{$_('features.revocation.title')} <span class="coming-soon">{$_('features.revocation.comingSoon')}</span></h3>
 			<p>{$_('features.revocation.description')}</p>
 		</div>
 	</div>
@@ -229,7 +223,15 @@
 		}
 
 		h3 {
-			margin: 0.6rem 0 0.35rem;
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			margin: 0 0 0.35rem;
+
+			:global(svg) {
+				color: var(--pg-primary);
+				flex-shrink: 0;
+			}
 		}
 
 		p {
@@ -237,10 +239,6 @@
 			font-size: var(--pg-font-size-md);
 			line-height: 1.5;
 		}
-	}
-
-	.bento-icon {
-		color: var(--pg-primary);
 	}
 
 	.coming-soon {

--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -13,87 +13,82 @@
 />
 
 <section class="hero">
-	<div class="hero-content">
-		<h1>{$_('hero.title')}</h1>
-		<p class="hero-subtitle">
-			{$_('hero.subtitle')}
-		</p>
-		<div class="hero-actions">
-			<a href="/register" class="primary-btn">{$_('hero.cta')}</a>
-			{#if data.marketingFlags.pricing}
-				<a href="/pricing" class="secondary-btn">{$_('hero.pricing')}</a>
-			{/if}
+	<div class="hero-inner">
+		<div class="hero-text">
+			<h1>{$_('hero.title')}</h1>
+			<p class="hero-subtitle">
+				{$_('hero.subtitle')}
+			</p>
+			<div class="hero-actions">
+				<a href="/register" class="primary-btn">{$_('hero.cta')}</a>
+				{#if data.marketingFlags.pricing}
+					<a href="/pricing" class="secondary-btn">{$_('hero.pricing')}</a>
+				{/if}
+			</div>
+		</div>
+		<div class="hero-visual">
+			<div class="visual-stack">
+				<div class="visual-card">
+					<Icon icon="mdi:lock-check" width="22" height="22" />
+					<span>{$_('features.encryption.title')}</span>
+				</div>
+				<div class="visual-card">
+					<Icon icon="mdi:shield-account" width="22" height="22" />
+					<span>{$_('features.identity.title')}</span>
+				</div>
+				<div class="visual-card accent">
+					<Icon icon="mdi:key-variant" width="22" height="22" />
+					<span>{$_('features.apiKeys.title')}</span>
+				</div>
+			</div>
 		</div>
 	</div>
 </section>
 
 <section class="features">
 	<h2 class="section-title">{$_('features.title')}</h2>
-	<div class="features-grid">
-		<div class="feature-card">
-			<div class="feature-icon">
-				<Icon icon="mdi:key-variant" width="32" height="32" />
-			</div>
+
+	<div class="bento">
+		<div class="bento-item wide">
+			<div class="bento-icon"><Icon icon="mdi:key-variant" width="28" height="28" /></div>
 			<h3>{$_('features.apiKeys.title')}</h3>
-			<p>
-				{$_('features.apiKeys.description')}
-			</p>
+			<p>{$_('features.apiKeys.description')}</p>
 		</div>
 
-		<div class="feature-card">
-			<div class="feature-icon">
-				<Icon icon="mdi:shield-account" width="32" height="32" />
-			</div>
+		<div class="bento-item">
+			<div class="bento-icon"><Icon icon="mdi:shield-account" width="28" height="28" /></div>
 			<h3>{$_('features.identity.title')}</h3>
-			<p>
-				{$_('features.identity.description')}
-			</p>
+			<p>{$_('features.identity.description')}</p>
 		</div>
 
-		<div class="feature-card">
-			<div class="feature-icon">
-				<Icon icon="mdi:server-security" width="32" height="32" />
-			</div>
+		<div class="bento-item">
+			<div class="bento-icon"><Icon icon="mdi:server-security" width="28" height="28" /></div>
 			<h3>{$_('features.hostedEU.title')}</h3>
-			<p>
-				{$_('features.hostedEU.description')}
-			</p>
+			<p>{$_('features.hostedEU.description')}</p>
 		</div>
 
-		<div class="feature-card">
-			<div class="feature-icon">
-				<Icon icon="mdi:lock-check" width="32" height="32" />
-			</div>
+		<div class="bento-item">
+			<div class="bento-icon"><Icon icon="mdi:lock-check" width="28" height="28" /></div>
 			<h3>{$_('features.encryption.title')}</h3>
-			<p>
-				{$_('features.encryption.description')}
-			</p>
+			<p>{$_('features.encryption.description')}</p>
 		</div>
 
-		<div class="feature-card">
-			<div class="feature-icon">
-				<Icon icon="mdi:source-branch" width="32" height="32" />
-			</div>
+		<div class="bento-item wide">
+			<div class="bento-icon"><Icon icon="mdi:source-branch" width="28" height="28" /></div>
 			<h3>{$_('features.openSource.title')}</h3>
-			<p>
-				{$_('features.openSource.description')}
-			</p>
+			<p>{$_('features.openSource.description')}</p>
 		</div>
 
-		<div class="feature-card">
-			<div class="feature-icon">
-				<Icon icon="mdi:email-remove" width="32" height="32" />
-			</div>
+		<div class="bento-item muted">
+			<div class="bento-icon"><Icon icon="mdi:email-remove" width="28" height="28" /></div>
 			<h3>{$_('features.revocation.title')} <span class="coming-soon">{$_('features.revocation.comingSoon')}</span></h3>
-			<p>
-				{$_('features.revocation.description')}
-			</p>
+			<p>{$_('features.revocation.description')}</p>
 		</div>
 	</div>
 </section>
 
 <section class="cta">
-	<div class="cta-content">
+	<div class="cta-inner">
 		<h2>{$_('cta.title')}</h2>
 		<p>{$_('cta.subtitle')}</p>
 		<a href="/register" class="primary-btn">{$_('cta.button')}</a>
@@ -101,29 +96,34 @@
 </section>
 
 <style lang="scss">
+	/* ── Hero ── */
 	.hero {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		padding: 3rem 1.5rem;
-		background: linear-gradient(
-			180deg,
-			var(--pg-soft-background) 0%,
-			var(--pg-general-background) 100%
-		);
+		padding: 4rem 1.5rem;
+		background: var(--pg-soft-background);
 	}
 
-	.hero-content {
-		max-width: 700px;
-		text-align: center;
+	.hero-inner {
+		max-width: 1100px;
+		margin: 0 auto;
+		display: grid;
+		grid-template-columns: 1.1fr 0.9fr;
+		gap: 3rem;
+		align-items: center;
 
+		@media only screen and (max-width: 800px) {
+			grid-template-columns: 1fr;
+			gap: 2rem;
+		}
+	}
+
+	.hero-text {
 		h1 {
-			font-size: 2.5rem;
-			line-height: 1.2;
+			font-size: 2.6rem;
+			line-height: 1.15;
 			margin-bottom: 1rem;
 
 			@media only screen and (max-width: 768px) {
-				font-size: 1.8rem;
+				font-size: 1.9rem;
 			}
 		}
 	}
@@ -133,52 +133,103 @@
 		color: var(--pg-text-secondary);
 		line-height: 1.6;
 		margin-bottom: 1.5rem;
+		max-width: 520px;
 	}
 
 	.hero-actions {
 		display: flex;
 		gap: 1rem;
-		justify-content: center;
 		flex-wrap: wrap;
 	}
 
+	.hero-visual {
+		display: flex;
+		justify-content: center;
+
+		@media only screen and (max-width: 800px) {
+			display: none;
+		}
+	}
+
+	.visual-stack {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		width: 280px;
+	}
+
+	.visual-card {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		background: var(--pg-general-background);
+		border: 1px solid var(--pg-strong-background);
+		border-radius: var(--pg-border-radius-md);
+		padding: 0.85rem 1rem;
+		font-size: var(--pg-font-size-md);
+		font-weight: var(--pg-font-weight-medium);
+		font-family: var(--pg-font-family);
+
+		:global(svg) {
+			color: var(--pg-primary);
+			flex-shrink: 0;
+		}
+
+		&.accent {
+			background: var(--pg-primary);
+			border-color: var(--pg-primary);
+			color: #fff;
+
+			:global(svg) {
+				color: #fff;
+			}
+
+			span {
+				color: #fff;
+			}
+		}
+	}
+
+	/* ── Features — bento grid ── */
 	.features {
-		max-width: 1200px;
+		max-width: 1100px;
 		margin: 0 auto;
-		padding: 2rem 1.5rem 4rem;
+		padding: 3rem 1.5rem 4rem;
 	}
 
 	.section-title {
-		text-align: center;
-		margin-bottom: 2.5rem;
+		margin-bottom: 2rem;
 	}
 
-	.features-grid {
+	.bento {
 		display: grid;
 		grid-template-columns: repeat(3, 1fr);
-		gap: 1.5rem;
+		gap: 1rem;
 
-		@media only screen and (max-width: 900px) {
-			grid-template-columns: repeat(2, 1fr);
-		}
-
-		@media only screen and (max-width: 600px) {
+		@media only screen and (max-width: 800px) {
 			grid-template-columns: 1fr;
 		}
 	}
 
-	.feature-card {
+	.bento-item {
 		background: var(--pg-soft-background);
 		border-radius: var(--pg-border-radius-lg);
 		padding: 1.5rem;
-		transition: transform 0.2s ease;
 
-		&:hover {
-			transform: translateY(-2px);
+		&.wide {
+			grid-column: span 2;
+
+			@media only screen and (max-width: 800px) {
+				grid-column: span 1;
+			}
+		}
+
+		&.muted {
+			opacity: 0.65;
 		}
 
 		h3 {
-			margin: 0.75rem 0 0.5rem;
+			margin: 0.6rem 0 0.35rem;
 		}
 
 		p {
@@ -186,6 +237,10 @@
 			font-size: var(--pg-font-size-md);
 			line-height: 1.5;
 		}
+	}
+
+	.bento-icon {
+		color: var(--pg-primary);
 	}
 
 	.coming-soon {
@@ -199,28 +254,25 @@
 		margin-left: 0.25rem;
 	}
 
-	.feature-icon {
-		color: var(--pg-primary);
-	}
-
+	/* ── CTA ── */
 	.cta {
-		background: var(--pg-soft-background);
+		border-top: 1px solid var(--pg-strong-background);
 		padding: 4rem 1.5rem;
-		text-align: center;
 	}
 
-	.cta-content {
-		max-width: 600px;
+	.cta-inner {
+		max-width: 1100px;
 		margin: 0 auto;
 
 		h2 {
-			margin-bottom: 0.75rem;
+			margin-bottom: 0.5rem;
 		}
 
 		p {
 			color: var(--pg-text-secondary);
 			font-size: var(--pg-font-size-lg);
 			margin-bottom: 1.5rem;
+			max-width: 500px;
 		}
 	}
 </style>

--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -48,35 +48,43 @@
 <section class="features">
 	<h2 class="section-title">{$_('features.title')}</h2>
 
-	<div class="bento">
-		<div class="bento-item wide">
-			<h3><Icon icon="mdi:key-variant" width="20" height="20" />{$_('features.apiKeys.title')}</h3>
-			<p>{$_('features.apiKeys.description')}</p>
+	<div class="feature-rows">
+		<div class="feature-row highlight-row">
+			<div class="row-icon"><Icon icon="mdi:key-variant" width="36" height="36" /></div>
+			<div class="row-body">
+				<h3>{$_('features.apiKeys.title')}</h3>
+				<p>{$_('features.apiKeys.description')}</p>
+			</div>
 		</div>
 
-		<div class="bento-item">
-			<h3><Icon icon="mdi:shield-account" width="20" height="20" />{$_('features.identity.title')}</h3>
-			<p>{$_('features.identity.description')}</p>
+		<div class="feature-pair">
+			<div class="bento-item">
+				<h3><Icon icon="mdi:shield-account" width="20" height="20" />{$_('features.identity.title')}</h3>
+				<p>{$_('features.identity.description')}</p>
+			</div>
+			<div class="bento-item">
+				<h3><Icon icon="mdi:lock-check" width="20" height="20" />{$_('features.encryption.title')}</h3>
+				<p>{$_('features.encryption.description')}</p>
+			</div>
 		</div>
 
-		<div class="bento-item">
-			<h3><Icon icon="mdi:server-security" width="20" height="20" />{$_('features.hostedEU.title')}</h3>
-			<p>{$_('features.hostedEU.description')}</p>
+		<div class="feature-row">
+			<div class="row-icon"><Icon icon="mdi:server-security" width="36" height="36" /></div>
+			<div class="row-body">
+				<h3>{$_('features.hostedEU.title')}</h3>
+				<p>{$_('features.hostedEU.description')}</p>
+			</div>
 		</div>
 
-		<div class="bento-item">
-			<h3><Icon icon="mdi:lock-check" width="20" height="20" />{$_('features.encryption.title')}</h3>
-			<p>{$_('features.encryption.description')}</p>
-		</div>
-
-		<div class="bento-item wide">
-			<h3><Icon icon="mdi:source-branch" width="20" height="20" />{$_('features.openSource.title')}</h3>
-			<p>{$_('features.openSource.description')}</p>
-		</div>
-
-		<div class="bento-item muted">
-			<h3><Icon icon="mdi:email-remove" width="20" height="20" />{$_('features.revocation.title')} <span class="coming-soon">{$_('features.revocation.comingSoon')}</span></h3>
-			<p>{$_('features.revocation.description')}</p>
+		<div class="feature-pair">
+			<div class="bento-item">
+				<h3><Icon icon="mdi:source-branch" width="20" height="20" />{$_('features.openSource.title')}</h3>
+				<p>{$_('features.openSource.description')}</p>
+			</div>
+			<div class="bento-item muted">
+				<h3><Icon icon="mdi:email-remove" width="20" height="20" />{$_('features.revocation.title')} <span class="coming-soon">{$_('features.revocation.comingSoon')}</span></h3>
+				<p>{$_('features.revocation.description')}</p>
+			</div>
 		</div>
 	</div>
 </section>
@@ -184,7 +192,7 @@
 		}
 	}
 
-	/* ── Features — bento grid ── */
+	/* ── Features ── */
 	.features {
 		max-width: 1100px;
 		margin: 0 auto;
@@ -195,12 +203,58 @@
 		margin-bottom: 2rem;
 	}
 
-	.bento {
+	.feature-rows {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	/* Full-width horizontal feature row */
+	.feature-row {
+		display: flex;
+		align-items: flex-start;
+		gap: 1.5rem;
+		padding: 1.75rem;
+		border: 1px solid var(--pg-strong-background);
+		border-radius: var(--pg-border-radius-lg);
+
+		&.highlight-row {
+			background: var(--pg-soft-background);
+			border: none;
+		}
+
+		@media only screen and (max-width: 600px) {
+			flex-direction: column;
+			gap: 0.75rem;
+		}
+	}
+
+	.row-icon {
+		color: var(--pg-primary);
+		flex-shrink: 0;
+		padding-top: 0.15rem;
+	}
+
+	.row-body {
+		h3 {
+			margin: 0 0 0.35rem;
+		}
+
+		p {
+			color: var(--pg-text-secondary);
+			font-size: var(--pg-font-size-md);
+			line-height: 1.5;
+			max-width: 600px;
+		}
+	}
+
+	/* Side-by-side compact pair */
+	.feature-pair {
 		display: grid;
-		grid-template-columns: repeat(3, 1fr);
+		grid-template-columns: 1fr 1fr;
 		gap: 1rem;
 
-		@media only screen and (max-width: 800px) {
+		@media only screen and (max-width: 600px) {
 			grid-template-columns: 1fr;
 		}
 	}
@@ -208,15 +262,7 @@
 	.bento-item {
 		background: var(--pg-soft-background);
 		border-radius: var(--pg-border-radius-lg);
-		padding: 1.5rem;
-
-		&.wide {
-			grid-column: span 2;
-
-			@media only screen and (max-width: 800px) {
-				grid-column: span 1;
-			}
-		}
+		padding: 1.25rem;
 
 		&.muted {
 			opacity: 0.65;

--- a/src/routes/(marketing)/pricing/+page.svelte
+++ b/src/routes/(marketing)/pricing/+page.svelte
@@ -1,95 +1,70 @@
 <script lang="ts">
 	import SEO from '$lib/components/SEO.svelte';
 	import Icon from '@iconify/svelte';
-
-	const plans = [
-		{
-			name: 'Starter',
-			price: 'Free',
-			period: '',
-			description: 'For small teams getting started with email signing.',
-			features: [
-				'Up to 3 API keys',
-				'100 signed emails/month',
-				'Basic audit log',
-				'Email support',
-				'1 domain'
-			],
-			cta: 'Get started',
-			href: '/register',
-			highlighted: false
-		},
-		{
-			name: 'Professional',
-			price: '\u20AC49',
-			period: '/month',
-			description: 'For growing organizations with advanced needs.',
-			features: [
-				'Unlimited API keys',
-				'10,000 signed emails/month',
-				'Full audit log with export',
-				'Priority support',
-				'5 domains',
-				'Read receipts',
-				'Email revocation'
-			],
-			cta: 'Start free trial',
-			href: '/register?plan=professional',
-			highlighted: true
-		},
-		{
-			name: 'Enterprise',
-			price: 'Custom',
-			period: '',
-			description: 'For large organizations with custom requirements.',
-			features: [
-				'Everything in Professional',
-				'Unlimited emails',
-				'Unlimited domains',
-				'Dedicated support',
-				'SLA guarantees',
-				'Custom integrations',
-				'On-premise option'
-			],
-			cta: 'Contact sales',
-			href: '/register?plan=enterprise',
-			highlighted: false
-		}
-	];
+	import { _ } from 'svelte-i18n';
 </script>
 
-<SEO title="Pricing" description="Choose the right PostGuard for Business plan for your organization." />
+<SEO title={$_('pricing.title')} description={$_('pricing.seoDescription')} />
 
 <section class="pricing-hero">
-	<h1>Simple, transparent pricing</h1>
-	<p>Choose the plan that fits your organization. All plans include DNS verification and Yivi-based authentication.</p>
+	<h1>{$_('pricing.heading')}</h1>
+	<p>{$_('pricing.subtitle')}</p>
 </section>
 
 <section class="pricing-grid">
-	{#each plans as plan}
-		<div class="plan-card" class:highlighted={plan.highlighted}>
-			{#if plan.highlighted}
-				<div class="plan-badge">Most popular</div>
-			{/if}
-			<h2>{plan.name}</h2>
-			<div class="plan-price">
-				<span class="price">{plan.price}</span>
-				{#if plan.period}<span class="period">{plan.period}</span>{/if}
-			</div>
-			<p class="plan-description">{plan.description}</p>
-			<a href={plan.href} class={plan.highlighted ? 'primary-btn' : 'secondary-btn'}>
-				{plan.cta}
-			</a>
-			<ul class="plan-features">
-				{#each plan.features as feature}
-					<li>
-						<Icon icon="mdi:check-circle" width="18" height="18" />
-						<span>{feature}</span>
-					</li>
-				{/each}
-			</ul>
+	<div class="plan-card">
+		<h2>{$_('pricing.small.name')}</h2>
+		<div class="plan-users">{$_('pricing.small.users')}</div>
+		<div class="plan-price">
+			<span class="price">{$_('pricing.small.price')}</span>
+			<span class="period">{$_('pricing.small.period')}</span>
 		</div>
-	{/each}
+		<p class="plan-description">{$_('pricing.small.description')}</p>
+		<a href="/register?plan=small" class="secondary-btn">{$_('pricing.small.cta')}</a>
+	</div>
+
+	<div class="plan-card highlighted">
+		<h2>{$_('pricing.medium.name')}</h2>
+		<div class="plan-users">{$_('pricing.medium.users')}</div>
+		<div class="plan-price">
+			<span class="price">{$_('pricing.medium.price')}</span>
+			<span class="period">{$_('pricing.medium.period')}</span>
+		</div>
+		<p class="plan-description">{$_('pricing.medium.description')}</p>
+		<a href="/register?plan=medium" class="primary-btn">{$_('pricing.medium.cta')}</a>
+	</div>
+
+	<div class="plan-card">
+		<h2>{$_('pricing.enterprise.name')}</h2>
+		<div class="plan-users">{$_('pricing.enterprise.users')}</div>
+		<div class="plan-price">
+			<span class="price">{$_('pricing.enterprise.price')}</span>
+		</div>
+		<p class="plan-description">{$_('pricing.enterprise.description')}</p>
+		<a href="/register?plan=enterprise" class="secondary-btn">{$_('pricing.enterprise.cta')}</a>
+	</div>
+</section>
+
+<section class="advantages">
+	<h2>{$_('pricing.advantages.title')}</h2>
+	<ul class="advantages-list">
+		<li>
+			<Icon icon="mdi:check-circle" width="20" height="20" />
+			<span>{$_('pricing.advantages.allIn')}</span>
+		</li>
+		<li>
+			<Icon icon="mdi:check-circle" width="20" height="20" />
+			<span>{$_('pricing.advantages.noFees')}</span>
+		</li>
+		<li>
+			<Icon icon="mdi:check-circle" width="20" height="20" />
+			<span>{$_('pricing.advantages.onboarding')}</span>
+		</li>
+		<li>
+			<Icon icon="mdi:check-circle" width="20" height="20" />
+			<span>{$_('pricing.advantages.contracts')}</span>
+		</li>
+	</ul>
 </section>
 
 <style lang="scss">
@@ -117,7 +92,7 @@
 		gap: 1.5rem;
 		max-width: 1100px;
 		margin: 0 auto;
-		padding: 2rem 1.5rem 4rem;
+		padding: 2rem 1.5rem 2rem;
 
 		@media only screen and (max-width: 900px) {
 			grid-template-columns: 1fr;
@@ -150,19 +125,10 @@
 		}
 	}
 
-	.plan-badge {
-		position: absolute;
-		top: -12px;
-		left: 50%;
-		transform: translateX(-50%);
-		background: var(--pg-primary);
-		color: #fff;
-		font-family: var(--pg-font-family);
-		font-size: var(--pg-font-size-xs);
-		font-weight: var(--pg-font-weight-bold);
-		padding: 4px 12px;
-		border-radius: 100px;
-		white-space: nowrap;
+	.plan-users {
+		font-size: var(--pg-font-size-sm);
+		color: var(--pg-text-secondary);
+		margin-bottom: 0.5rem;
 	}
 
 	.plan-price {
@@ -186,19 +152,32 @@
 		font-size: var(--pg-font-size-md);
 		margin-bottom: 1.5rem;
 		line-height: 1.5;
+		flex: 1;
 	}
 
-	.plan-features {
+	.advantages {
+		max-width: 600px;
+		margin: 0 auto;
+		padding: 1rem 1.5rem 4rem;
+		text-align: center;
+
+		h2 {
+			margin-bottom: 1.25rem;
+		}
+	}
+
+	.advantages-list {
 		list-style: none;
 		padding: 0;
-		margin: 1.5rem 0 0;
-		flex: 1;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
 
 		li {
 			display: flex;
 			align-items: center;
+			justify-content: center;
 			gap: 0.5rem;
-			padding: 0.4rem 0;
 			font-size: var(--pg-font-size-md);
 			color: var(--pg-text);
 

--- a/src/routes/(marketing)/pricing/+page.svelte
+++ b/src/routes/(marketing)/pricing/+page.svelte
@@ -69,9 +69,9 @@
 
 <style lang="scss">
 	.pricing-hero {
-		text-align: center;
+		max-width: 1100px;
+		margin: 0 auto;
 		padding: 4rem 1.5rem 2rem;
-		background: linear-gradient(180deg, var(--pg-soft-background) 0%, var(--pg-general-background) 100%);
 
 		h1 {
 			font-size: 2.2rem;
@@ -81,8 +81,7 @@
 		p {
 			color: var(--pg-text-secondary);
 			font-size: var(--pg-font-size-lg);
-			max-width: 600px;
-			margin: 0 auto;
+			max-width: 500px;
 		}
 	}
 
@@ -116,7 +115,6 @@
 
 		&.highlighted {
 			border-color: var(--pg-primary);
-			box-shadow: 0 4px 20px rgba(124, 58, 237, 0.15);
 		}
 
 		h2 {
@@ -156,13 +154,12 @@
 	}
 
 	.advantages {
-		max-width: 600px;
+		max-width: 1100px;
 		margin: 0 auto;
-		padding: 1rem 1.5rem 4rem;
-		text-align: center;
+		padding: 1.5rem 1.5rem 4rem;
 
 		h2 {
-			margin-bottom: 1.25rem;
+			margin-bottom: 1rem;
 		}
 	}
 
@@ -170,13 +167,12 @@
 		list-style: none;
 		padding: 0;
 		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
+		flex-wrap: wrap;
+		gap: 0.5rem 2rem;
 
 		li {
 			display: flex;
 			align-items: center;
-			justify-content: center;
 			gap: 0.5rem;
 			font-size: var(--pg-font-size-md);
 			color: var(--pg-text);

--- a/src/routes/(marketing)/register/+page.svelte
+++ b/src/routes/(marketing)/register/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import SEO from '$lib/components/SEO.svelte';
 	import { enhance } from '$app/forms';
 	import Icon from '@iconify/svelte';
@@ -114,8 +115,8 @@
 </script>
 
 <SEO
-	title="Register"
-	description="Register your organization for PostGuard for Business."
+	title={$_('register.title')}
+	description={$_('register.seoDescription')}
 />
 
 <section class="register">
@@ -123,43 +124,41 @@
 		{#if form?.success}
 			<div class="success-message">
 				<Icon icon="mdi:check-circle" width="48" height="48" />
-				<h1>Application submitted</h1>
+				<h1>{$_('register.submitted')}</h1>
 				<p>
-					Thank you for registering. We will review your application and get back to you
-					within 2 business days. You will receive a confirmation email once your
-					organization is approved.
+					{$_('register.submittedMessage')}
 				</p>
-				<a href="/" class="secondary-btn">Back to home</a>
+				<a href="/" class="secondary-btn">{$_('register.backHome')}</a>
 			</div>
 		{:else if yiviStatus === 'idle' || yiviStatus === 'running' || yiviStatus === 'error'}
-			<h1>Register your organization</h1>
+			<h1>{$_('register.heading')}</h1>
 			<p class="register-subtitle">
-				Verify your identity with the Yivi app to register your organization for PostGuard for Business.
+				{$_('register.subtitle')}
 			</p>
 
 			{#if yiviStatus === 'idle'}
 				<div class="yivi-section">
 					<button class="primary-btn yivi-btn" onclick={startYiviFlow}>
 						<Icon icon="mdi:qrcode-scan" width="20" height="20" />
-						Verify with Yivi
+						{$_('register.verifyBtn')}
 					</button>
 				</div>
 			{:else if yiviStatus === 'running'}
 				<div class="yivi-section">
 					<div id="yivi-register-container" class="yivi-container"></div>
-					<p class="yivi-hint">Please disclose your email, full name, and phone number.</p>
+					<p class="yivi-hint">{$_('register.yiviHint')}</p>
 				</div>
 			{:else if yiviStatus === 'error'}
 				<div class="yivi-section error-state">
 					<Icon icon="mdi:alert-circle" width="32" height="32" />
 					<p>{yiviError}</p>
-					<button class="secondary-btn" onclick={retryYivi}>Try again</button>
+					<button class="secondary-btn" onclick={retryYivi}>{$_('auth.tryAgain')}</button>
 				</div>
 			{/if}
 		{:else if disclosed}
-			<h1>Complete registration</h1>
+			<h1>{$_('register.completeTitle')}</h1>
 			<p class="register-subtitle">
-				Your identity has been verified. Fill in the remaining details below.
+				{$_('register.completeSubtitle')}
 			</p>
 
 			{#if form?.errors?.form}
@@ -171,22 +170,22 @@
 
 			<div class="disclosed-info">
 				<div class="disclosed-field">
-					<span class="disclosed-label">Full name</span>
+					<span class="disclosed-label">{$_('register.fullName')}</span>
 					<span class="disclosed-value">{disclosed.fullName}</span>
 				</div>
 				<div class="disclosed-field">
-					<span class="disclosed-label">Email</span>
+					<span class="disclosed-label">{$_('register.email')}</span>
 					<span class="disclosed-value">{disclosed.email}</span>
 				</div>
 				{#if disclosed.phone}
 					<div class="disclosed-field">
-						<span class="disclosed-label">Phone</span>
+						<span class="disclosed-label">{$_('register.phone')}</span>
 						<span class="disclosed-value">{disclosed.phone}</span>
 					</div>
 				{/if}
 				<div class="disclosed-badge">
 					<Icon icon="mdi:check-decagram" width="16" height="16" />
-					Verified with Yivi
+					{$_('register.verifiedYivi')}
 				</div>
 			</div>
 
@@ -197,13 +196,13 @@
 				<input type="hidden" name="domain" value={derivedDomain} />
 
 				<div class="form-group">
-					<label for="name">Organization name *</label>
+					<label for="name">{$_('register.orgName')} *</label>
 					<input
 						id="name"
 						name="name"
 						type="text"
 						class="pg-input"
-						placeholder="Acme B.V."
+						placeholder={$_('register.orgNamePlaceholder')}
 						value={form?.values?.name ?? ''}
 						required
 					/>
@@ -219,7 +218,7 @@
 					</div>
 				{/if}
 
-				<button type="submit" class="primary-btn submit-btn">Submit application</button>
+				<button type="submit" class="primary-btn submit-btn">{$_('register.submit')}</button>
 			</form>
 		{/if}
 	</div>

--- a/src/routes/(portal)/+layout.svelte
+++ b/src/routes/(portal)/+layout.svelte
@@ -1,29 +1,31 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import Icon from '@iconify/svelte';
 	import logoLight from '$lib/assets/images/logo.svg';
 	import logoDark from '$lib/assets/images/logo-dark.svg';
 	import ThemeSwitcher from '$lib/components/ThemeSwitcher.svelte';
+	import LocaleSwitcher from '$lib/components/LocaleSwitcher.svelte';
 	import type { LayoutData } from './$types';
 
 	let { data, children }: { data: LayoutData; children: import('svelte').Snippet } = $props();
 	let sidebarOpen = $state(false);
 
 	const navItems = $derived([
-		{ href: '/portal/dashboard', label: 'Dashboard', icon: 'mdi:view-dashboard' },
+		{ href: '/portal/dashboard', label: $_('nav.dashboard'), icon: 'mdi:view-dashboard' },
 		...(data.featureFlags.apiKeys
-			? [{ href: '/portal/api-keys', label: 'API Keys', icon: 'mdi:key-variant' }]
+			? [{ href: '/portal/api-keys', label: $_('nav.apiKeys'), icon: 'mdi:key-variant' }]
 			: []),
 		...(data.featureFlags.orgInfo
-			? [{ href: '/portal/organization', label: 'Organization', icon: 'mdi:office-building' }]
+			? [{ href: '/portal/organization', label: $_('nav.organization'), icon: 'mdi:office-building' }]
 			: []),
 		...(data.featureFlags.emailLog
-			? [{ href: '/portal/email-log', label: 'Email Log', icon: 'mdi:email-search' }]
+			? [{ href: '/portal/email-log', label: $_('nav.emailLog'), icon: 'mdi:email-search' }]
 			: []),
 		...(data.featureFlags.members
-			? [{ href: '/portal/members', label: 'Members', icon: 'mdi:account-group' }]
+			? [{ href: '/portal/members', label: $_('nav.members'), icon: 'mdi:account-group' }]
 			: []),
 		...(data.featureFlags.dns
-			? [{ href: '/portal/dns', label: 'DNS Verification', icon: 'mdi:dns' }]
+			? [{ href: '/portal/dns', label: $_('nav.dns'), icon: 'mdi:dns' }]
 			: [])
 	]);
 </script>
@@ -31,9 +33,9 @@
 {#if data.isImpersonating}
 	<div class="impersonation-bar">
 		<Icon icon="mdi:eye" width="16" height="16" />
-		<span>Viewing as <strong>{data.organization.name}</strong></span>
+		<span>{$_('admin.viewingAs', { values: { orgName: data.organization.name } })}</span>
 		<form method="POST" action="/api/admin/impersonate/stop">
-			<button type="submit" class="stop-btn">Stop impersonating</button>
+			<button type="submit" class="stop-btn">{$_('admin.stopImpersonating')}</button>
 		</form>
 	</div>
 {/if}
@@ -68,7 +70,7 @@
 			<form method="POST" action="/auth/logout">
 				<button type="submit" class="nav-item logout-btn">
 					<Icon icon="mdi:logout" width="20" height="20" />
-					<span>Log out</span>
+					<span>{$_('nav.logout')}</span>
 				</button>
 			</form>
 		</div>
@@ -81,6 +83,7 @@
 			</button>
 			<h2 class="portal-title">{data.organization.name}</h2>
 			<div class="header-actions">
+				<LocaleSwitcher />
 				<ThemeSwitcher />
 			</div>
 		</header>

--- a/src/routes/(portal)/portal/api-keys/+page.svelte
+++ b/src/routes/(portal)/portal/api-keys/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import SEO from '$lib/components/SEO.svelte';
 	import Icon from '@iconify/svelte';
 	import { enhance } from '$app/forms';
@@ -8,33 +9,33 @@
 	let confirmDelete = $state<string | null>(null);
 </script>
 
-<SEO title="API Keys" />
+<SEO title={$_('apiKeys.title')} />
 
 <div class="page-header">
-	<h1>API Keys</h1>
+	<h1>{$_('apiKeys.title')}</h1>
 	<a href="/portal/api-keys/create" class="primary-btn">
 		<Icon icon="mdi:plus" width="18" height="18" />
-		Create key
+		{$_('apiKeys.createKey')}
 	</a>
 </div>
 
 {#if data.keys.length === 0}
 	<div class="empty-state">
 		<Icon icon="mdi:key-variant" width="48" height="48" />
-		<h3>No API keys yet</h3>
-		<p>Create your first API key to start signing emails.</p>
-		<a href="/portal/api-keys/create" class="secondary-btn">Create API key</a>
+		<h3>{$_('apiKeys.emptyTitle')}</h3>
+		<p>{$_('apiKeys.emptyDescription')}</p>
+		<a href="/portal/api-keys/create" class="secondary-btn">{$_('apiKeys.createApiKey')}</a>
 	</div>
 {:else}
 	<div class="table-wrapper">
 		<table>
 			<thead>
 				<tr>
-					<th>Name</th>
-					<th>Key prefix</th>
-					<th>Created</th>
-					<th>Last used</th>
-					<th>Expires</th>
+					<th>{$_('apiKeys.name')}</th>
+					<th>{$_('apiKeys.keyPrefix')}</th>
+					<th>{$_('apiKeys.created')}</th>
+					<th>{$_('apiKeys.lastUsed')}</th>
+					<th>{$_('apiKeys.expires')}</th>
 					<th></th>
 				</tr>
 			</thead>
@@ -48,7 +49,7 @@
 							{#if key.lastUsedAt}
 								{new Date(key.lastUsedAt).toLocaleDateString()}
 							{:else}
-								<span class="muted">Never</span>
+								<span class="muted">{$_('apiKeys.never')}</span>
 							{/if}
 						</td>
 						<td>{new Date(key.expiresAt).toLocaleDateString()}</td>
@@ -57,9 +58,9 @@
 								<form method="POST" action="?/revoke" use:enhance>
 									<input type="hidden" name="keyId" value={key.id} />
 									<div class="confirm-row">
-										<button type="submit" class="danger-btn">Confirm</button>
+										<button type="submit" class="danger-btn">{$_('apiKeys.confirm')}</button>
 										<button type="button" class="ghost-btn" onclick={() => (confirmDelete = null)}>
-											Cancel
+											{$_('apiKeys.cancel')}
 										</button>
 									</div>
 								</form>

--- a/src/routes/(portal)/portal/api-keys/create/+page.svelte
+++ b/src/routes/(portal)/portal/api-keys/create/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import SEO from '$lib/components/SEO.svelte';
 	import Icon from '@iconify/svelte';
 	import { enhance } from '$app/forms';
@@ -16,34 +17,34 @@
 	}
 </script>
 
-<SEO title="Create API Key" />
+<SEO title={$_('apiKeys.create.title')} />
 
 {#if form?.success && form?.rawKey}
 	<div class="key-created">
 		<div class="key-created-icon">
 			<Icon icon="mdi:key-chain" width="48" height="48" />
 		</div>
-		<h1>API key created</h1>
+		<h1>{$_('apiKeys.create.created')}</h1>
 		<p class="warning">
 			<Icon icon="mdi:alert" width="18" height="18" />
-			Copy this key now. You won't be able to see it again.
+			{$_('apiKeys.create.copyWarning')}
 		</p>
 		<div class="key-display">
 			<code>{form.rawKey}</code>
 			<button class="ghost-btn copy-btn" onclick={copyKey}>
 				<Icon icon={copied ? 'mdi:check' : 'mdi:content-copy'} width="18" height="18" />
-				{copied ? 'Copied!' : 'Copy'}
+				{copied ? $_('apiKeys.create.copied') : $_('apiKeys.create.copy')}
 			</button>
 		</div>
-		<a href="/portal/api-keys" class="secondary-btn back-btn">Back to API keys</a>
+		<a href="/portal/api-keys" class="secondary-btn back-btn">{$_('apiKeys.create.backToKeys')}</a>
 	</div>
 {:else}
 	<div class="page-header">
 		<a href="/portal/api-keys" class="back-link">
 			<Icon icon="mdi:arrow-left" width="18" height="18" />
-			Back
+			{$_('apiKeys.create.back')}
 		</a>
-		<h1>Create API key</h1>
+		<h1>{$_('apiKeys.create.title')}</h1>
 	</div>
 
 	{#if form?.error}
@@ -55,55 +56,55 @@
 
 	<form method="POST" use:enhance class="create-form">
 		<div class="form-group">
-			<label for="name">Key name</label>
+			<label for="name">{$_('apiKeys.create.keyName')}</label>
 			<input
 				id="name"
 				name="name"
 				type="text"
 				class="pg-input"
-				placeholder="e.g. Production Mailer"
+				placeholder={$_('apiKeys.create.keyNamePlaceholder')}
 				value={form?.values?.name ?? ''}
 				required
 			/>
-			<span class="field-hint">A descriptive name to identify this key</span>
+			<span class="field-hint">{$_('apiKeys.create.keyNameHint')}</span>
 		</div>
 
 		<div class="form-group">
-			<label for="expiryDays">Expires in</label>
+			<label for="expiryDays">{$_('apiKeys.create.expiresIn')}</label>
 			<select id="expiryDays" name="expiryDays" class="pg-input">
-				<option value="30">30 days</option>
-				<option value="90">90 days</option>
-				<option value="180">180 days</option>
-				<option value="365" selected>1 year</option>
+				<option value="30">{$_('apiKeys.create.days30')}</option>
+				<option value="90">{$_('apiKeys.create.days90')}</option>
+				<option value="180">{$_('apiKeys.create.days180')}</option>
+				<option value="365" selected>{$_('apiKeys.create.year1')}</option>
 			</select>
 		</div>
 
 		<fieldset class="signing-attrs">
-			<legend>Signing attributes</legend>
-			<p class="field-hint">Choose which organizational attributes this API key will include when signing emails.</p>
+			<legend>{$_('apiKeys.create.signingAttrs')}</legend>
+			<p class="field-hint">{$_('apiKeys.create.signingHint')}</p>
 
 			<label class="checkbox-label">
 				<input type="checkbox" name="signEmail" checked />
-				<span>Email address</span>
+				<span>{$_('apiKeys.create.attrEmail')}</span>
 			</label>
 
 			<label class="checkbox-label">
 				<input type="checkbox" name="signOrgName" checked />
-				<span>Organization name</span>
+				<span>{$_('apiKeys.create.attrOrgName')}</span>
 			</label>
 
 			<label class="checkbox-label">
 				<input type="checkbox" name="signPhone" />
-				<span>Phone number</span>
+				<span>{$_('apiKeys.create.attrPhone')}</span>
 			</label>
 
 			<label class="checkbox-label">
 				<input type="checkbox" name="signKvkNumber" />
-				<span>KvK number</span>
+				<span>{$_('apiKeys.create.attrKvk')}</span>
 			</label>
 		</fieldset>
 
-		<button type="submit" class="primary-btn">Generate API key</button>
+		<button type="submit" class="primary-btn">{$_('apiKeys.create.generate')}</button>
 	</form>
 {/if}
 

--- a/src/routes/(portal)/portal/dashboard/+page.svelte
+++ b/src/routes/(portal)/portal/dashboard/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import SEO from '$lib/components/SEO.svelte';
 	import Icon from '@iconify/svelte';
 	import type { PageData } from './$types';
@@ -6,9 +7,9 @@
 	let { data }: { data: PageData } = $props();
 </script>
 
-<SEO title="Dashboard" />
+<SEO title={$_('dashboard.title')} />
 
-<h1>Dashboard</h1>
+<h1>{$_('dashboard.title')}</h1>
 
 <div class="stats-grid">
 	{#if data.featureFlags.apiKeys}
@@ -18,9 +19,9 @@
 			</div>
 			<div class="stat-info">
 				<p class="stat-value">{data.stats.activeKeys}</p>
-				<p class="stat-label">Active API keys</p>
+				<p class="stat-label">{$_('dashboard.activeKeys')}</p>
 			</div>
-			<a href="/portal/api-keys" class="stat-link">Manage</a>
+			<a href="/portal/api-keys" class="stat-link">{$_('dashboard.manage')}</a>
 		</div>
 	{/if}
 
@@ -31,9 +32,9 @@
 			</div>
 			<div class="stat-info">
 				<p class="stat-value">{data.stats.emailsThisMonth}</p>
-				<p class="stat-label">Emails this month</p>
+				<p class="stat-label">{$_('dashboard.emailsMonth')}</p>
 			</div>
-			<a href="/portal/email-log" class="stat-link">View log</a>
+			<a href="/portal/email-log" class="stat-link">{$_('dashboard.viewLog')}</a>
 		</div>
 	{/if}
 
@@ -47,33 +48,33 @@
 				/>
 			</div>
 			<div class="stat-info">
-				<p class="stat-value">{data.stats.dnsVerified ? 'Verified' : 'Pending'}</p>
-				<p class="stat-label">DNS status</p>
+				<p class="stat-value">{data.stats.dnsVerified ? $_('dashboard.verified') : $_('dashboard.pending')}</p>
+				<p class="stat-label">{$_('dashboard.dnsStatus')}</p>
 			</div>
-			<a href="/portal/dns" class="stat-link">Configure</a>
+			<a href="/portal/dns" class="stat-link">{$_('dashboard.configure')}</a>
 		</div>
 	{/if}
 </div>
 
 <section class="quick-actions">
-	<h2>Quick actions</h2>
+	<h2>{$_('dashboard.quickActions')}</h2>
 	<div class="actions-row">
 		{#if data.featureFlags.apiKeys}
 			<a href="/portal/api-keys/create" class="action-card">
 				<Icon icon="mdi:key-plus" width="24" height="24" />
-				<span>Create API key</span>
+				<span>{$_('dashboard.createKey')}</span>
 			</a>
 		{/if}
 		{#if data.featureFlags.orgInfo}
 			<a href="/portal/organization" class="action-card">
 				<Icon icon="mdi:office-building-cog" width="24" height="24" />
-				<span>Edit organization</span>
+				<span>{$_('dashboard.editOrg')}</span>
 			</a>
 		{/if}
 		{#if data.featureFlags.emailLog}
 			<a href="/portal/email-log" class="action-card">
 				<Icon icon="mdi:file-document-outline" width="24" height="24" />
-				<span>Export audit log</span>
+				<span>{$_('dashboard.exportLog')}</span>
 			</a>
 		{/if}
 	</div>

--- a/src/routes/(portal)/portal/dns/+page.svelte
+++ b/src/routes/(portal)/portal/dns/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import SEO from '$lib/components/SEO.svelte';
 	import Icon from '@iconify/svelte';
 	import { enhance } from '$app/forms';
@@ -14,9 +15,9 @@
 	}
 </script>
 
-<SEO title="DNS Verification" />
+<SEO title={$_('dns.title')} />
 
-<h1>DNS Verification</h1>
+<h1>{$_('dns.title')}</h1>
 
 <div class="status-card" class:verified={data.dns.verified}>
 	<div class="status-header">
@@ -26,12 +27,12 @@
 			height="28"
 		/>
 		<div>
-			<h2>{data.dns.verified ? 'Domain verified' : 'Verification pending'}</h2>
+			<h2>{data.dns.verified ? $_('dns.domainVerified') : $_('dns.verificationPending')}</h2>
 			<p class="domain">{data.dns.domain}</p>
 		</div>
 	</div>
 	{#if data.dns.verifiedAt}
-		<p class="verified-date">Verified on {new Date(data.dns.verifiedAt).toLocaleDateString()}</p>
+		<p class="verified-date">{$_('dns.verifiedOn', { values: { date: new Date(data.dns.verifiedAt).toLocaleDateString() } })}</p>
 	{/if}
 </div>
 
@@ -45,29 +46,29 @@
 {#if form?.verified}
 	<div class="verify-success" role="status">
 		<Icon icon="mdi:check-circle" width="18" height="18" />
-		<span>DNS verified successfully!</span>
+		<span>{$_('dns.verifiedSuccess')}</span>
 	</div>
 {/if}
 
 <section class="instructions">
-	<h2>Setup Instructions</h2>
+	<h2>{$_('dns.instructions')}</h2>
 
 	<div class="step">
 		<div class="step-number">1</div>
 		<div class="step-content">
-			<h3>Add TXT record</h3>
-			<p>Add the following TXT record to your domain's DNS configuration:</p>
+			<h3>{$_('dns.step1Title')}</h3>
+			<p>{$_('dns.step1Desc')}</p>
 			<div class="record-box">
 				<div class="record-field">
-					<span class="record-label">Type</span>
+					<span class="record-label">{$_('dns.type')}</span>
 					<code>TXT</code>
 				</div>
 				<div class="record-field">
-					<span class="record-label">Name/Host</span>
+					<span class="record-label">{$_('dns.nameHost')}</span>
 					<code>@</code>
 				</div>
 				<div class="record-field">
-					<span class="record-label">Value</span>
+					<span class="record-label">{$_('dns.value')}</span>
 					<div class="record-value-row">
 						<code>{data.dns.txtRecord}</code>
 						<button class="ghost-btn copy-btn" onclick={copyRecord}>
@@ -82,24 +83,24 @@
 	<div class="step">
 		<div class="step-number">2</div>
 		<div class="step-content">
-			<h3>Wait for propagation</h3>
-			<p>DNS changes can take up to 48 hours to propagate, though most changes are visible within minutes.</p>
+			<h3>{$_('dns.step2Title')}</h3>
+			<p>{$_('dns.step2Desc')}</p>
 		</div>
 	</div>
 
 	<div class="step">
 		<div class="step-number">3</div>
 		<div class="step-content">
-			<h3>Verify</h3>
-			<p>Click the button below to check if your DNS records are configured correctly.</p>
+			<h3>{$_('dns.step3Title')}</h3>
+			<p>{$_('dns.step3Desc')}</p>
 			<form method="POST" action="?/verify" use:enhance>
 				<button type="submit" class="primary-btn">
 					<Icon icon="mdi:check-network" width="18" height="18" />
-					Verify DNS
+					{$_('dns.verifyBtn')}
 				</button>
 			</form>
 			{#if data.dns.lastCheckedAt}
-				<p class="last-check">Last checked: {new Date(data.dns.lastCheckedAt).toLocaleString()}</p>
+				<p class="last-check">{$_('dns.lastChecked', { values: { date: new Date(data.dns.lastCheckedAt).toLocaleString() } })}</p>
 			{/if}
 		</div>
 	</div>

--- a/src/routes/(portal)/portal/email-log/+page.svelte
+++ b/src/routes/(portal)/portal/email-log/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import SEO from '$lib/components/SEO.svelte';
 	import Icon from '@iconify/svelte';
 	import { enhance } from '$app/forms';
@@ -16,10 +17,10 @@
 	}
 </script>
 
-<SEO title="Email Log" />
+<SEO title={$_('emailLog.title')} />
 
 <div class="page-header">
-	<h1>Email Audit Log</h1>
+	<h1>{$_('emailLog.heading')}</h1>
 </div>
 
 <div class="search-bar">
@@ -28,27 +29,27 @@
 			<input
 				type="text"
 				class="pg-input"
-				placeholder="Search by recipient or subject..."
+				placeholder={$_('emailLog.searchPlaceholder')}
 				bind:value={searchInput}
 			/>
 			<button type="submit" class="secondary-btn">
 				<Icon icon="mdi:magnify" width="18" height="18" />
-				Search
+				{$_('emailLog.search')}
 			</button>
 		</div>
 	</form>
-	<p class="result-count">{data.emailLogs.total} email{data.emailLogs.total !== 1 ? 's' : ''} found</p>
+	<p class="result-count">{$_('emailLog.emailsFound', { values: { count: data.emailLogs.total } })}</p>
 </div>
 
 {#if data.emailLogs.logs.length === 0}
 	<div class="empty-state">
 		<Icon icon="mdi:email-search" width="48" height="48" />
-		<h3>No emails found</h3>
+		<h3>{$_('emailLog.noEmails')}</h3>
 		<p>
 			{#if data.search}
-				No emails match your search.
+				{$_('emailLog.noSearchMatch')}
 			{:else}
-				No signed emails yet. Emails will appear here once your API keys are used.
+				{$_('emailLog.noEmailsYet')}
 			{/if}
 		</p>
 	</div>
@@ -57,11 +58,11 @@
 		<table>
 			<thead>
 				<tr>
-					<th>Recipient</th>
-					<th>Subject</th>
-					<th>Signed</th>
-					<th>Read</th>
-					<th>Status</th>
+					<th>{$_('emailLog.recipient')}</th>
+					<th>{$_('emailLog.subject')}</th>
+					<th>{$_('emailLog.signed')}</th>
+					<th>{$_('emailLog.read')}</th>
+					<th>{$_('emailLog.statusCol')}</th>
 					<th></th>
 				</tr>
 			</thead>
@@ -78,14 +79,14 @@
 									{new Date(email.readAt).toLocaleDateString()}
 								</span>
 							{:else}
-								<span class="muted">Not read</span>
+								<span class="muted">{$_('emailLog.notRead')}</span>
 							{/if}
 						</td>
 						<td>
 							{#if email.revokedAt}
-								<span class="revoked-badge">Revoked</span>
+								<span class="revoked-badge">{$_('emailLog.revoked')}</span>
 							{:else}
-								<span class="active-badge">Active</span>
+								<span class="active-badge">{$_('emailLog.active')}</span>
 							{/if}
 						</td>
 						<td>
@@ -94,15 +95,15 @@
 									<form method="POST" action="?/revoke" use:enhance>
 										<input type="hidden" name="emailId" value={email.id} />
 										<div class="confirm-row">
-											<button type="submit" class="danger-btn">Revoke</button>
+											<button type="submit" class="danger-btn">{$_('emailLog.revoke')}</button>
 											<button type="button" class="ghost-btn" onclick={() => (confirmRevoke = null)}>
-												Cancel
+												{$_('emailLog.cancel')}
 											</button>
 										</div>
 									</form>
 								{:else}
 									<button class="ghost-btn danger" onclick={() => (confirmRevoke = email.id)}>
-										Revoke
+										{$_('emailLog.revoke')}
 									</button>
 								{/if}
 							{/if}
@@ -117,13 +118,13 @@
 		<div class="pagination">
 			{#if data.emailLogs.page > 1}
 				<a href="/portal/email-log?page={data.emailLogs.page - 1}{data.search ? `&search=${data.search}` : ''}" class="secondary-btn">
-					Previous
+					{$_('emailLog.previous')}
 				</a>
 			{/if}
-			<span class="page-info">Page {data.emailLogs.page} of {data.emailLogs.totalPages}</span>
+			<span class="page-info">{$_('emailLog.pageOf', { values: { page: data.emailLogs.page, totalPages: data.emailLogs.totalPages } })}</span>
 			{#if data.emailLogs.page < data.emailLogs.totalPages}
 				<a href="/portal/email-log?page={data.emailLogs.page + 1}{data.search ? `&search=${data.search}` : ''}" class="secondary-btn">
-					Next
+					{$_('emailLog.next')}
 				</a>
 			{/if}
 		</div>

--- a/src/routes/(portal)/portal/members/+page.svelte
+++ b/src/routes/(portal)/portal/members/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import SEO from '$lib/components/SEO.svelte';
 	import Icon from '@iconify/svelte';
 	import { enhance } from '$app/forms';
@@ -9,13 +10,13 @@
 	let confirmRemove = $state<string | null>(null);
 </script>
 
-<SEO title="Members" />
+<SEO title={$_('members.title')} />
 
 <div class="page-header">
-	<h1>Members</h1>
+	<h1>{$_('members.title')}</h1>
 	<button class="primary-btn" onclick={() => (showAddForm = !showAddForm)}>
 		<Icon icon="mdi:plus" width="18" height="18" />
-		Add member
+		{$_('members.addMember')}
 	</button>
 </div>
 
@@ -29,20 +30,20 @@
 {#if form?.added}
 	<div class="success-banner" role="status">
 		<Icon icon="mdi:check-circle" width="20" height="20" />
-		<span>Member added successfully.</span>
+		<span>{$_('members.memberAdded')}</span>
 	</div>
 {/if}
 
 {#if form?.contactChanged}
 	<div class="success-banner" role="status">
 		<Icon icon="mdi:check-circle" width="20" height="20" />
-		<span>Contact person updated.</span>
+		<span>{$_('members.contactUpdated')}</span>
 	</div>
 {/if}
 
 {#if showAddForm}
 	<div class="add-form-card">
-		<h3>Add a new member</h3>
+		<h3>{$_('members.addTitle')}</h3>
 		<form method="POST" action="?/add" use:enhance={() => {
 			return async ({ update, result }) => {
 				if (result.type === 'success') showAddForm = false;
@@ -50,20 +51,20 @@
 			};
 		}}>
 			<div class="form-row">
-				<label for="fullName">Full name</label>
+				<label for="fullName">{$_('members.fullName')}</label>
 				<input id="fullName" name="fullName" type="text" class="pg-input" required />
 			</div>
 			<div class="form-row">
-				<label for="email">Email</label>
+				<label for="email">{$_('members.email')}</label>
 				<input id="email" name="email" type="email" class="pg-input" required />
 			</div>
 			<div class="form-row">
-				<label for="phone">Phone <span class="optional">(optional)</span></label>
+				<label for="phone">{$_('members.phone')} <span class="optional">{$_('members.optional')}</span></label>
 				<input id="phone" name="phone" type="tel" class="pg-input" />
 			</div>
 			<div class="form-actions">
-				<button type="submit" class="primary-btn">Add member</button>
-				<button type="button" class="ghost-btn" onclick={() => (showAddForm = false)}>Cancel</button>
+				<button type="submit" class="primary-btn">{$_('members.addMember')}</button>
+				<button type="button" class="ghost-btn" onclick={() => (showAddForm = false)}>{$_('members.cancel')}</button>
 			</div>
 		</form>
 	</div>
@@ -72,18 +73,18 @@
 {#if data.members.length === 0}
 	<div class="empty-state">
 		<Icon icon="mdi:account-group" width="48" height="48" />
-		<h3>No members yet</h3>
-		<p>Add the first member to your organization.</p>
+		<h3>{$_('members.emptyTitle')}</h3>
+		<p>{$_('members.emptyDescription')}</p>
 	</div>
 {:else}
 	<div class="table-wrapper">
 		<table>
 			<thead>
 				<tr>
-					<th>Name</th>
-					<th>Email</th>
-					<th>Phone</th>
-					<th>Role</th>
+					<th>{$_('members.name')}</th>
+					<th>{$_('members.email')}</th>
+					<th>{$_('members.phone')}</th>
+					<th>{$_('members.role')}</th>
 					<th></th>
 				</tr>
 			</thead>
@@ -95,16 +96,16 @@
 						<td>{member.phone ?? '—'}</td>
 						<td>
 							{#if member.id === data.organization.contactUserId}
-								<span class="contact-badge">Contact person</span>
+								<span class="contact-badge">{$_('members.contactPerson')}</span>
 							{:else}
-								<span class="muted">Member</span>
+								<span class="muted">{$_('members.member')}</span>
 							{/if}
 						</td>
 						<td class="actions-cell">
 							{#if member.id !== data.organization.contactUserId}
 								<form method="POST" action="?/setContact" use:enhance class="inline-form">
 									<input type="hidden" name="userId" value={member.id} />
-									<button type="submit" class="ghost-btn" title="Make contact person">
+									<button type="submit" class="ghost-btn" title={$_('members.makeContact')}>
 										<Icon icon="mdi:account-star" width="18" height="18" />
 									</button>
 								</form>
@@ -113,12 +114,12 @@
 								<form method="POST" action="?/remove" use:enhance>
 									<input type="hidden" name="userId" value={member.id} />
 									<div class="confirm-row">
-										<button type="submit" class="danger-btn">Remove</button>
-										<button type="button" class="ghost-btn" onclick={() => (confirmRemove = null)}>Cancel</button>
+										<button type="submit" class="danger-btn">{$_('members.remove')}</button>
+										<button type="button" class="ghost-btn" onclick={() => (confirmRemove = null)}>{$_('members.cancel')}</button>
 									</div>
 								</form>
 							{:else if member.id !== data.organization.contactUserId && member.id !== data.user?.id}
-								<button class="ghost-btn danger" onclick={() => (confirmRemove = member.id)} title="Remove member">
+								<button class="ghost-btn danger" onclick={() => (confirmRemove = member.id)} title={$_('members.removeMember')}>
 									<Icon icon="mdi:delete" width="18" height="18" />
 								</button>
 							{/if}

--- a/src/routes/(portal)/portal/organization/+page.svelte
+++ b/src/routes/(portal)/portal/organization/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import SEO from '$lib/components/SEO.svelte';
 	import Icon from '@iconify/svelte';
 	import { enhance } from '$app/forms';
@@ -13,11 +14,11 @@
 	const contactPerson = $derived(data.contactPerson);
 
 	const fields = $derived([
-		{ key: 'name', label: 'Organization name', value: org.name, editable: true },
-		{ key: 'domain', label: 'Domain', value: org.domain, editable: true },
-		{ key: 'signingEmail', label: 'Signing email', value: org.signingEmail, editable: true },
-		{ key: 'kvkNumber', label: 'KvK number', value: org.kvkNumber ?? '—', editable: true },
-		{ key: 'contactPerson', label: 'Contact person', value: contactPerson ? `${contactPerson.fullName} (${contactPerson.email})` : '—', editable: false }
+		{ key: 'name', label: $_('organization.orgName'), value: org.name, editable: true },
+		{ key: 'domain', label: $_('organization.domain'), value: org.domain, editable: true },
+		{ key: 'signingEmail', label: $_('organization.signingEmail'), value: org.signingEmail, editable: true },
+		{ key: 'kvkNumber', label: $_('organization.kvkNumber'), value: org.kvkNumber ?? '—', editable: true },
+		{ key: 'contactPerson', label: $_('organization.contactPerson'), value: contactPerson ? `${contactPerson.fullName} (${contactPerson.email})` : '—', editable: false }
 	]);
 
 	function startEdit(key: string, currentValue: string) {
@@ -31,14 +32,14 @@
 	}
 </script>
 
-<SEO title="Organization" />
+<SEO title={$_('organization.title')} />
 
-<h1>Organization Details</h1>
+<h1>{$_('organization.details')}</h1>
 
 {#if form?.submitted}
 	<div class="success-banner" role="status">
 		<Icon icon="mdi:check-circle" width="20" height="20" />
-		<span>Change request for <strong>{form.fieldName}</strong> submitted. An admin will review it.</span>
+		<span>{$_('organization.changeSubmitted', { values: { fieldName: form.fieldName } })}</span>
 	</div>
 {/if}
 
@@ -85,7 +86,7 @@
 				{:else}
 					<button class="ghost-btn edit-btn" onclick={() => startEdit(field.key, field.value)}>
 						<Icon icon="mdi:pencil" width="16" height="16" />
-						Request change
+						{$_('organization.requestChange')}
 					</button>
 				{/if}
 			{/if}
@@ -95,15 +96,15 @@
 
 {#if data.requests.length > 0}
 	<section class="requests-section">
-		<h2>Change Requests</h2>
+		<h2>{$_('organization.changeRequests')}</h2>
 		<div class="table-wrapper">
 			<table>
 				<thead>
 					<tr>
-						<th>Field</th>
-						<th>New value</th>
-						<th>Status</th>
-						<th>Requested</th>
+						<th>{$_('organization.field')}</th>
+						<th>{$_('organization.newValue')}</th>
+						<th>{$_('organization.status')}</th>
+						<th>{$_('organization.requested')}</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import { page } from '$app/state';
 	import Icon from '@iconify/svelte';
 </script>
@@ -11,8 +12,8 @@
 			height="56"
 		/>
 		<h1>{page.status}</h1>
-		<p>{page.error?.message || 'Something went wrong'}</p>
-		<button class="secondary-btn" onclick={() => history.back()}>Go back</button>
+		<p>{page.error?.message || $_('common.somethingWrong')}</p>
+		<button class="secondary-btn" onclick={() => history.back()}>{$_('common.goBack')}</button>
 	</div>
 </div>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import '$lib/global.scss';
-	import '$lib/i18n';
 	import { locale } from 'svelte-i18n';
 
 	let { children } = $props();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,15 @@
 <script lang="ts">
 	import '$lib/global.scss';
+	import '$lib/i18n';
+	import { locale } from 'svelte-i18n';
 
 	let { children } = $props();
+
+	$effect(() => {
+		if ($locale) {
+			document.documentElement.lang = $locale.substring(0, 2);
+		}
+	});
 </script>
 
 <div id="app">

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,0 +1,8 @@
+import '$lib/i18n';
+import { waitLocale } from 'svelte-i18n';
+import type { LayoutLoad } from './$types';
+
+export const load: LayoutLoad = async ({ data }) => {
+	await waitLocale();
+	return data;
+};

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import SEO from '$lib/components/SEO.svelte';
 	import ThemeSwitcher from '$lib/components/ThemeSwitcher.svelte';
 	import YiviLogin from '$lib/components/YiviLogin.svelte';
@@ -18,7 +19,7 @@
 	}
 </script>
 
-<SEO title="Login" description="Log in to your PostGuard for Business account." />
+<SEO title={$_('auth.login')} description={$_('auth.loginSubtitle')} />
 
 <section class="login-page">
 	<div class="login-header">
@@ -29,18 +30,18 @@
 		<ThemeSwitcher />
 	</div>
 	<div class="login-card">
-		<h1>Log in</h1>
+		<h1>{$_('auth.login')}</h1>
 		<p class="login-subtitle">
-			Authenticate with your Yivi app to access your organization portal.
+			{$_('auth.loginSubtitle')}
 		</p>
 
 		<div class="login-content">
-			<p class="login-hint">Disclose your organization email address to log in.</p>
+			<p class="login-hint">{$_('auth.loginHint')}</p>
 			<YiviLogin type="org" attrs={data.yiviAttrs} onSuccess={handleSuccess} />
 		</div>
 
 		<p class="login-footer">
-			Don't have an account? <a href="/register">Register your organization</a>
+			{$_('auth.noAccount')} <a href="/register">{$_('auth.registerOrg')}</a>
 		</p>
 	</div>
 </section>

--- a/src/routes/auth/login/admin/+page.svelte
+++ b/src/routes/auth/login/admin/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { _ } from 'svelte-i18n';
 	import SEO from '$lib/components/SEO.svelte';
 	import ThemeSwitcher from '$lib/components/ThemeSwitcher.svelte';
 	import YiviLogin from '$lib/components/YiviLogin.svelte';
@@ -15,7 +16,7 @@
 	}
 </script>
 
-<SEO title="Admin Login" />
+<SEO title={$_('auth.adminLogin')} />
 
 <section class="login-page">
 	<div class="login-header">
@@ -26,9 +27,9 @@
 		<ThemeSwitcher />
 	</div>
 	<div class="login-card">
-		<h1>Admin Login</h1>
+		<h1>{$_('auth.adminLogin')}</h1>
 		<p class="login-subtitle">
-			Disclose your full name, email address, and phone number to log in as an administrator.
+			{$_('auth.adminLoginSubtitle')}
 		</p>
 
 		<div class="login-content">

--- a/tests/e2e/landing.e2e.ts
+++ b/tests/e2e/landing.e2e.ts
@@ -3,12 +3,12 @@ import { test, expect } from '@playwright/test';
 test.describe('Landing page', () => {
 	test('should display the hero section', async ({ page }) => {
 		await page.goto('/');
-		await expect(page.locator('h1')).toContainText('Secure email signing');
+		await expect(page.locator('.hero h1')).toBeVisible();
 	});
 
 	test('should display feature cards', async ({ page }) => {
 		await page.goto('/');
-		await expect(page.locator('.feature-card')).toHaveCount(6);
+		await expect(page.locator('.bento-item')).toHaveCount(6);
 	});
 
 	test('should have working navigation links', async ({ page }) => {
@@ -22,7 +22,7 @@ test.describe('Landing page', () => {
 		await page.goto('/');
 		const cta = page.locator('.cta');
 		await expect(cta).toBeVisible();
-		await expect(cta.locator('a.primary-btn')).toContainText('Register');
+		await expect(cta.locator('a.primary-btn')).toBeVisible();
 	});
 
 	test('should have a footer', async ({ page }) => {

--- a/tests/e2e/landing.e2e.ts
+++ b/tests/e2e/landing.e2e.ts
@@ -6,9 +6,11 @@ test.describe('Landing page', () => {
 		await expect(page.locator('.hero h1')).toBeVisible();
 	});
 
-	test('should display feature cards', async ({ page }) => {
+	test('should display features section', async ({ page }) => {
 		await page.goto('/');
-		await expect(page.locator('.bento-item')).toHaveCount(6);
+		await expect(page.locator('.features')).toBeVisible();
+		await expect(page.locator('.feature-row')).toHaveCount(2);
+		await expect(page.locator('.bento-item')).toHaveCount(4);
 	});
 
 	test('should have working navigation links', async ({ page }) => {

--- a/tests/e2e/landing.e2e.ts
+++ b/tests/e2e/landing.e2e.ts
@@ -9,8 +9,7 @@ test.describe('Landing page', () => {
 	test('should display features section', async ({ page }) => {
 		await page.goto('/');
 		await expect(page.locator('.features')).toBeVisible();
-		await expect(page.locator('.feature-row')).toHaveCount(2);
-		await expect(page.locator('.bento-item')).toHaveCount(4);
+		await expect(page.locator('.feature-block')).toHaveCount(6);
 	});
 
 	test('should have working navigation links', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Wires up `svelte-i18n` with NL/EN locale switcher (matching postguard-website approach)
- Replaces all ~250 hardcoded strings with `$_()` calls across all 28 `.svelte` files
- Adds `LocaleSwitcher` component to marketing Header, portal sidebar, and admin sidebar
- Restructures pricing page: per-user tiers (Small €5–€6, Medium €4–€5, Enterprise custom) with shared advantages section
- Fixes sticky footer (short pages no longer leave whitespace below footer)
- Removes premature DNS verification claims from marketing copy

### i18n approach
- Locale detection: `localStorage` > browser `navigator.language` > fallback `en-US`
- Server hook reads `accept-language` header for SSR
- `html[lang]` attribute set reactively
- Translation files: `src/lib/locales/en.json` and `src/lib/locales/nl.json`

### Files changed
- **New:** `LocaleSwitcher.svelte`
- **Config:** `i18n.ts`, `hooks.server.ts`, `global.scss`, root `+layout.svelte`
- **Locale files:** `en.json`, `nl.json` (expanded from ~60 to ~320 keys each)
- **All pages:** marketing (3), portal (8 + layout), admin (6 + layout), auth (2), error page
- **Components:** Header, Footer, YiviLogin

## Test plan
- [ ] Toggle NL/EN in marketing header — all text switches
- [ ] Toggle NL/EN in portal sidebar — nav items and page content switch
- [ ] Toggle NL/EN in admin sidebar — same
- [ ] Verify pricing page shows 3 tiers with shared advantages below
- [ ] Verify footer sticks to bottom on short pages (e.g. login)
- [ ] Verify locale persists across page navigations (localStorage)
- [ ] `npm run check` passes
- [ ] `npm run build` passes