### PR TITLE
fix(seo): structured data, canonical tags, security headers, sitemap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Site URL (used for canonical tags, OG images, JSON-LD)
+PUBLIC_SITE_URL=http://localhost:5173
+
 # Database
 DATABASE_URL="postgres://user:password@localhost:5432/postguard_business"
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -17,5 +17,12 @@ export const handle: Handle = async ({ event, resolve }) => {
 		locale.set(lang);
 	}
 
-	return resolve(event);
+	const response = await resolve(event);
+
+	response.headers.set('X-Frame-Options', 'DENY');
+	response.headers.set('X-Content-Type-Options', 'nosniff');
+	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+	response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+
+	return response;
 };

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -20,12 +20,12 @@
 
 		<div class="footer-links">
 			<div class="link-group">
-				<h2>{$_('footer.product')}</h2>
+				<span class="group-title">{$_('footer.product')}</span>
 				<a href="/pricing">{$_('nav.pricing')}</a>
 				<a href="/register">{$_('nav.register')}</a>
 			</div>
 			<div class="link-group">
-				<h2>{$_('footer.resources')}</h2>
+				<span class="group-title">{$_('footer.resources')}</span>
 				<a href="https://postguard.eu" target="_blank" rel="noopener">{$_('footer.personal')}</a>
 				<a href="https://docs.postguard.eu" target="_blank" rel="noopener">{$_('footer.docs')}</a>
 			</div>
@@ -83,7 +83,8 @@
 		flex-direction: column;
 		gap: 0.5rem;
 
-		h2 {
+		.group-title {
+			display: block;
 			font-size: var(--pg-font-size-sm);
 			font-weight: var(--pg-font-weight-bold);
 			color: var(--pg-text-secondary);

--- a/src/lib/components/SEO.svelte
+++ b/src/lib/components/SEO.svelte
@@ -1,25 +1,43 @@
 <script lang="ts">
+	import { page } from '$app/state';
+	import { env } from '$env/dynamic/public';
+
 	let {
 		title = '',
 		description = '',
 		ogImage = '',
 		ogType = 'website',
-		canonical = ''
+		canonical = '',
+		jsonLd = null as Record<string, unknown> | Record<string, unknown>[] | null
 	} = $props();
+
 	const siteName = 'PostGuard for Business';
 	const defaultDescription =
 		'PostGuard for Business offers enterprise-grade identity-based email signing and encryption for organizations.';
-	const defaultImage = '/pg_logo.png';
+
+	const siteUrl = $derived(env.PUBLIC_SITE_URL || `${page.url.protocol}//${page.url.host}`);
+	const defaultImage = $derived(`${siteUrl}/pg_logo.png`);
+	const canonicalUrl = $derived(canonical || `${siteUrl}${page.url.pathname}`);
+	const isStaging = $derived(page.url.hostname.includes('staging'));
+	const jsonLdString = $derived(jsonLd ? JSON.stringify(Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : null);
 </script>
 
 <svelte:head>
 	<title>{title ? `${title} | ${siteName}` : siteName}</title>
 	<meta name="description" content={description || defaultDescription} />
+	<link rel="canonical" href={canonicalUrl} />
+	{#if isStaging}
+		<meta name="robots" content="noindex, nofollow" />
+	{/if}
 	<meta property="og:title" content={title || siteName} />
 	<meta property="og:description" content={description || defaultDescription} />
 	<meta property="og:image" content={ogImage || defaultImage} />
+	<meta property="og:url" content={canonicalUrl} />
 	<meta property="og:type" content={ogType} />
 	<meta property="og:site_name" content={siteName} />
-	{#if canonical}<link rel="canonical" href={canonical} />{/if}
 	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:image" content={ogImage || defaultImage} />
+	{#if jsonLdString}
+		{@html `<script type="application/ld+json">${jsonLdString}</script>`}
+	{/if}
 </svelte:head>

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -80,7 +80,7 @@
 	"seo": {
 		"siteName": "PostGuard for Business",
 		"defaultDescription": "PostGuard for Business offers enterprise-grade identity-based email signing and encryption for organizations.",
-		"homeTitle": "Enterprise Email Signing & Encryption",
+		"homeTitle": "Secure Email Signing for Your Organization",
 		"homeDescription": "PostGuard for Business offers enterprise-grade identity-based email signing and encryption. Manage API keys and audit email activity."
 	},
 	"pricing": {

--- a/src/lib/locales/nl.json
+++ b/src/lib/locales/nl.json
@@ -80,7 +80,7 @@
 	"seo": {
 		"siteName": "PostGuard for Business",
 		"defaultDescription": "PostGuard for Business biedt enterprise-grade identiteitsgebaseerde e-mailondertekening en versleuteling voor organisaties.",
-		"homeTitle": "Enterprise e-mailondertekening en versleuteling",
+		"homeTitle": "Veilige e-mailondertekening voor uw organisatie",
 		"homeDescription": "PostGuard for Business biedt enterprise-grade identiteitsgebaseerde e-mailondertekening en versleuteling. Beheer API-sleutels en controleer e-mailactiviteit."
 	},
 	"pricing": {

--- a/src/routes/(admin)/admin/api-keys/+page.svelte
+++ b/src/routes/(admin)/admin/api-keys/+page.svelte
@@ -87,8 +87,6 @@
 		margin-bottom: 1.5rem;
 		font-size: var(--pg-font-size-sm);
 		color: #16a34a;
-
-		code { word-break: break-all; }
 	}
 
 	.table-wrapper { overflow-x: auto; }

--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -5,11 +5,63 @@
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
+
+	const jsonLd = [
+		{
+			'@context': 'https://schema.org',
+			'@type': 'Organization',
+			name: 'PostGuard for Business',
+			url: 'https://business.postguard.eu',
+			logo: {
+				'@type': 'ImageObject',
+				url: 'https://business.postguard.eu/pg_logo.png'
+			},
+			description:
+				'PostGuard for Business offers enterprise-grade identity-based email signing and encryption for organizations.',
+			sameAs: ['https://postguard.eu', 'https://docs.postguard.eu']
+		},
+		{
+			'@context': 'https://schema.org',
+			'@type': 'WebSite',
+			name: 'PostGuard for Business',
+			url: 'https://business.postguard.eu'
+		},
+		{
+			'@context': 'https://schema.org',
+			'@type': 'SoftwareApplication',
+			name: 'PostGuard for Business',
+			url: 'https://business.postguard.eu',
+			applicationCategory: 'BusinessApplication',
+			operatingSystem: 'Web',
+			description:
+				'Identity-based email signing and end-to-end encryption for organizations. Manage API keys, audit email activity, and verify domain ownership.',
+			featureList: [
+				'API Key Management',
+				'Identity-Based Email Signing',
+				'End-to-End Encryption',
+				'Email Audit Log',
+				'GDPR-compliant EU hosting'
+			],
+			offers: {
+				'@type': 'AggregateOffer',
+				priceCurrency: 'EUR',
+				lowPrice: '4',
+				highPrice: '6',
+				priceSpecification: {
+					'@type': 'UnitPriceSpecification',
+					price: '4',
+					priceCurrency: 'EUR',
+					unitText: 'per user per month'
+				}
+			}
+		}
+	];
 </script>
 
 <SEO
 	title={$_('seo.homeTitle')}
 	description={$_('seo.homeDescription')}
+	{jsonLd}
 />
 
 <section class="hero">

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,32 @@
+import { env } from '$env/dynamic/public';
+import { isEnabled } from '$lib/feature-flags';
+
+export const GET = () => {
+	const siteUrl = env.PUBLIC_SITE_URL || 'https://business.postguard.eu';
+
+	const pages = [
+		{ path: '/', priority: '1.0', changefreq: 'weekly' },
+		...(isEnabled('registration')
+			? [{ path: '/register', priority: '0.8', changefreq: 'monthly' }]
+			: []),
+		...(isEnabled('pricingPage')
+			? [{ path: '/pricing', priority: '0.8', changefreq: 'monthly' }]
+			: [])
+	];
+
+	const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${pages.map((p) => `  <url>
+    <loc>${siteUrl}${p.path}</loc>
+    <changefreq>${p.changefreq}</changefreq>
+    <priority>${p.priority}</priority>
+  </url>`).join('\n')}
+</urlset>`;
+
+	return new Response(xml, {
+		headers: {
+			'Content-Type': 'application/xml',
+			'Cache-Control': 'max-age=3600'
+		}
+	});
+};

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,8 @@
-# allow crawling everything by default
 User-agent: *
-Disallow:
+Disallow: /portal/
+Disallow: /admin/
+Disallow: /api/
+Disallow: /auth/
+Disallow: /irma/
+
+Sitemap: https://business.postguard.eu/sitemap.xml


### PR DESCRIPTION
## Summary

SEO improvements based on a page analysis that scored 38/100. Addresses all critical and high-priority findings.

### Structured Data
- Organization, WebSite, and SoftwareApplication JSON-LD schemas on homepage
- JSON-LD support added to SEO component via `jsonLd` prop

### Meta Tags
- Canonical tag on every page (auto-generated from `PUBLIC_SITE_URL` + pathname)
- `noindex, nofollow` on staging environments (hostname detection)
- `og:image` now uses absolute URL
- Added `og:url`, `twitter:image`

### Security Headers
- `X-Frame-Options: DENY`
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy: camera=(), microphone=(), geolocation=()`

### Sitemap & Robots
- Dynamic XML sitemap at `/sitemap.xml` (respects feature flags for pricing/registration)
- `robots.txt` blocks `/portal/`, `/admin/`, `/api/`, `/auth/`, `/irma/` and references sitemap

### Other
- Footer headings changed from `<h2>` to `<span>` (not document-level headings)
- H1 and title tag aligned on homepage
- New `PUBLIC_SITE_URL` env var for canonical/OG base URL

## Env changes

Add to deployment config:
```
PUBLIC_SITE_URL=https://business.postguard.eu  # (or staging URL)
```
Already added to postguard-ops main.tf (derived from `business_host`).

## Test plan
- [ ] Homepage source contains JSON-LD with Organization, WebSite, SoftwareApplication
- [ ] Every page has `<link rel="canonical">` with correct absolute URL
- [ ] Staging pages have `<meta name="robots" content="noindex, nofollow">`
- [ ] `og:image` is an absolute URL
- [ ] `/sitemap.xml` returns valid XML with homepage, pricing, register
- [ ] `robots.txt` blocks portal/admin/api paths
- [ ] Response headers include security headers
- [ ] Footer uses `<span>` not `<h2>` for group titles
- [ ] `npm run check` passes
- [ ] `npm run test:unit` passes