### PR TITLE
ci: add semantic PR title check workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,14 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  lint-pr-title:
+    name: Conventional Commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-title.yml` running `amannn/action-semantic-pull-request@v5` on PR open/edit/sync/reopen.
- Mirrors the workflow already in use in `postguard-website` so PR titles follow Conventional Commits across the org.

## Test plan
- [ ] Workflow appears under Actions on this PR and the "Conventional Commit" check passes (this PR title is `ci: …`).
- [ ] Edit the PR title to a non-conventional value and confirm the check fails, then revert.

Closes #51