### PR TITLE
fix(csp): resolve report-only violations for inline script and Iconify API

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,12 +1,27 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import adapter from '@sveltejs/adapter-node';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+// SvelteKit's auto-CSP only nonces/hashes scripts it injects; the inline
+// <script> in src/app.html (dark-mode flash prevention) is not covered. We
+// derive its sha256 here so script-src stays in sync with the file content.
+const appHtml = readFileSync(new URL('./src/app.html', import.meta.url), 'utf8');
+const inlineScriptBody = appHtml.match(/<script>([\s\S]*?)<\/script>/)?.[1];
+if (!inlineScriptBody) {
+	throw new Error(
+		'svelte.config.js: could not locate inline <script> in src/app.html for CSP hashing'
+	);
+}
+/** @type {`sha256-${string}`} */
+const inlineScriptHash = `sha256-${createHash('sha256').update(inlineScriptBody).digest('base64')}`;
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	preprocess: [vitePreprocess()],
 	compilerOptions: {
 		// Force runes mode for the project, except for libraries. Can be removed in svelte 6.
-		runes: ({ filename }) => filename.split(/[/\\]/).includes('node_modules') ? undefined : true
+		runes: ({ filename }) => (filename.split(/[/\\]/).includes('node_modules') ? undefined : true)
 	},
 	kit: {
 		adapter: adapter({ out: 'build' }),
@@ -14,11 +29,12 @@ const config = {
 			mode: 'auto',
 			reportOnly: {
 				'default-src': ['self'],
-				'script-src': ['self'],
+				'script-src': ['self', inlineScriptHash],
 				'style-src': ['self', 'unsafe-inline'],
 				'img-src': ['self', 'data:'],
 				'font-src': ['self'],
-				'connect-src': ['self'],
+				// @iconify/svelte fetches MDI icon metadata from the Iconify API at runtime.
+				'connect-src': ['self', 'https://api.iconify.design'],
 				'frame-ancestors': ['none'],
 				'base-uri': ['self'],
 				'form-action': ['self'],

--- a/tests/unit/csp-config.test.ts
+++ b/tests/unit/csp-config.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import config from '../../svelte.config.js';
 
@@ -32,8 +34,20 @@ describe('SvelteKit CSP configuration', () => {
 		expect(scriptSrc).not.toContain('unsafe-eval');
 	});
 
+	it('pins a sha256 hash matching the inline <script> in app.html', () => {
+		const appHtml = readFileSync(new URL('../../src/app.html', import.meta.url), 'utf8');
+		const inlineScriptBody = appHtml.match(/<script>([\s\S]*?)<\/script>/)?.[1];
+		expect(inlineScriptBody, 'src/app.html should contain an inline <script>').toBeDefined();
+		const expected = `sha256-${createHash('sha256').update(inlineScriptBody!).digest('base64')}`;
+		expect(csp!.reportOnly!['script-src']).toContain(expected);
+	});
+
 	it('allows data: images for inline icon SVGs', () => {
 		expect(csp!.reportOnly!['img-src']).toContain('data:');
+	});
+
+	it('allows the Iconify API in connect-src for @iconify/svelte icon loading', () => {
+		expect(csp!.reportOnly!['connect-src']).toContain('https://api.iconify.design');
 	});
 
 	it('points violations at the in-app CSP report sink', () => {


### PR DESCRIPTION
## Summary
Resolves the two CSP report-only violations logged on staging in #60:

- **`script-src`** — the dark-mode-flash-prevention inline `<script>` in `src/app.html` had no nonce/hash. SvelteKit's auto-CSP only covers scripts it injects via `%sveltekit.head%`, not custom ones in `app.html`. Fixed by computing the script body's sha256 at config-load time and pinning the resulting `sha256-…` source in `script-src`. The hash auto-tracks the file content, so future Prettier reformats of `app.html` won't desync the policy.
- **`connect-src`** — `@iconify/svelte` fetches MDI icon metadata from `https://api.iconify.design` at runtime. Allowlisted that single host.

`tests/unit/csp-config.test.ts` was extended with two assertions:
- recompute the sha256 from `src/app.html` and assert `script-src` contains it
- assert `connect-src` includes the Iconify API host

Closes #60

## Test plan
- [x] `npm run test:unit` — 52/52 passing
- [x] `npm run check` — 0 errors / 0 warnings
- [x] `npm run build` — succeeds
- [x] Pre-commit hook (svelte-check + migration check) passes
- [ ] Verify on staging that the two report-only entries no longer fire