### PR TITLE
fix(a11y): use .visually-hidden for skip-link to remove visible 1px sliver

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,26 +11,26 @@
 	});
 </script>
 
-<a href="#main-content" class="skip-link">Skip to main content</a>
+<a href="#main-content" class="skip-link visually-hidden">Skip to main content</a>
 
 <div id="app">
 	{@render children()}
 </div>
 
 <style>
-	.skip-link {
+	.skip-link:focus {
 		position: absolute;
-		top: -40px;
+		top: 0;
 		left: 0;
+		width: auto;
+		height: auto;
+		overflow: visible;
 		padding: 8px 16px;
 		background: var(--pg-primary-bg, #7c3aed);
 		color: #fff;
 		text-decoration: none;
-		z-index: 1000;
-	}
-	.skip-link:focus {
-		top: 0;
 		outline: 2px solid #fff;
 		outline-offset: 2px;
+		z-index: 1000;
 	}
 </style>


### PR DESCRIPTION
## Summary
- The global skip-link in `src/routes/+layout.svelte` was hidden via `top: -40px`, but with 8px vertical padding + default line-height the element rendered slightly taller than 40px, leaving a 1px sliver of the link visible at the top-left for all users.
- Refactored to use the existing `.visually-hidden` utility from `src/lib/global.scss` for the default off-screen state, with a local `:focus` rule that brings the link back on-screen with its styled background and outline.
- The link remains in the DOM, focusable, and announced by screen readers — only its visible footprint changes.

## Test plan
- [ ] Load the app in a browser at any viewport — confirm no visible bar/sliver at the top-left when unfocused.
- [ ] Tab once after a fresh page load — confirm the "Skip to main content" link appears in the top-left with the purple background and white outline.
- [ ] Activate the link (Enter) and confirm focus moves to `#main-content`.
- [ ] Verify on portal, admin, and marketing routes (all share the root `+layout.svelte`).

/dobby please review