### PR TITLE
ci: add security scanning (CodeQL, dependency review, secret scan)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '27 4 * * 1' # Mondays 04:27 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,64 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  # Fails a PR that introduces a dependency with a high+ advisory.
+  # Delta-based: gates NEW risk without tripping on pre-existing debt.
+  dependency-review:
+    name: Dependency Review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+
+  # Scans the diff for committed secrets. TruffleHog is used instead of
+  # gitleaks-action, which requires a paid licence for organisation accounts.
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --results=verified,unknown
+
+  # Full-tree audit. Intentionally NON-BLOCKING for now: the tree currently
+  # has a pre-existing dev-only high advisory (vite/esbuild dev server).
+  # Flip `continue-on-error` off once the tree is clean.
+  npm-audit:
+    name: npm audit (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit
+        run: npm audit --audit-level=high
+        continue-on-error: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,13 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  # Flags a PR that introduces a dependency with a high+ advisory.
+  # Fails a PR that introduces a dependency with a high+ advisory.
   # Delta-based: gates NEW risk without tripping on pre-existing debt.
-  #
-  # NON-BLOCKING for now: this repo has the GitHub Dependency graph disabled,
-  # so the action cannot run yet. An admin must enable it under
-  # Settings → Code security → Dependency graph. Once enabled, remove
-  # `continue-on-error` below to turn this into a real gate.
   dependency-review:
     name: Dependency Review
     if: github.event_name == 'pull_request'
@@ -26,7 +21,6 @@ jobs:
 
       - name: Dependency review
         uses: actions/dependency-review-action@v4
-        continue-on-error: true
         with:
           fail-on-severity: high
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,8 +9,13 @@ permissions:
   contents: read
 
 jobs:
-  # Fails a PR that introduces a dependency with a high+ advisory.
+  # Flags a PR that introduces a dependency with a high+ advisory.
   # Delta-based: gates NEW risk without tripping on pre-existing debt.
+  #
+  # NON-BLOCKING for now: this repo has the GitHub Dependency graph disabled,
+  # so the action cannot run yet. An admin must enable it under
+  # Settings → Code security → Dependency graph. Once enabled, remove
+  # `continue-on-error` below to turn this into a real gate.
   dependency-review:
     name: Dependency Review
     if: github.event_name == 'pull_request'
@@ -21,6 +26,7 @@ jobs:
 
       - name: Dependency review
         uses: actions/dependency-review-action@v4
+        continue-on-error: true
         with:
           fail-on-severity: high
 


### PR DESCRIPTION
Closes #103.

Adds automated security scanning to CI. Kept as standalone workflows so the existing `ci.yml` (build / test / release) stays focused. These workflows run on this PR, so their first results are visible in the Checks tab.

## What's added

- **`.github/workflows/codeql.yml`** — CodeQL SAST for JavaScript/TypeScript on PRs, pushes to `main`, and a weekly schedule (`security-extended` query pack). Findings surface in the Security tab.
- **`.github/workflows/security.yml`**
  - **Dependency review** (PRs) — fails a PR that introduces a dependency with a `high`+ advisory. Delta-based, so it gates *new* risk without tripping on pre-existing debt. Active gate (the Dependency graph has been enabled on the repo).
  - **Secret scan** — TruffleHog over the diff. (Chosen over `gitleaks-action`, which requires a paid licence for organisation accounts.)
  - **npm audit (advisory)** — full-tree `npm audit --audit-level=high`, intentionally **non-blocking** (`continue-on-error`).

## Why `npm audit` is non-blocking

`npm audit` currently reports 1 high advisory — a Windows-only dev-server issue in `vite`/`esbuild`, which are dev dependencies and not in the runtime image. Gating on the full tree would fail CI immediately on pre-existing, low-real-risk debt. The advisory job keeps it visible; cleaning it up (`npm audit fix`) is better handled as its own dependency bump. Flip `continue-on-error` off once the tree is clean.

## Follow-ups (repo settings — can't be done in a PR)

- Enable GitHub secret scanning + push protection (free for public repos).
- Add the new checks to branch-protection required status checks once they've had a green run.
- Clean up the pre-existing dev-only `vite`/`esbuild` advisory (`npm audit fix`) and flip the `npm audit` job to blocking.
