### PR TITLE
docs: add CODEOWNERS and issue/PR templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners are automatically requested for review on matching PRs.
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Default owner for everything. Adjust to a team (e.g. @encryption4all/<team>)
+# or add path-specific rules below as the maintainer set grows.
+* @rubenhensen

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Report a problem with PostGuard for Business
+title: ''
+labels: bug
+---
+
+## What happened
+
+<!-- A clear description of the bug. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behaviour
+
+<!-- What you expected to happen instead. -->
+
+## Environment
+
+- Version / commit / image tag:
+- Browser & OS (if relevant):
+
+## Additional context
+
+<!-- Logs, screenshots, or anything else useful. Do NOT paste secrets. -->
+
+<!--
+Found a security vulnerability? Do not file it here — report it privately.
+See SECURITY.md.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/encryption4all/postguard-business/security/advisories/new
+    about: Please report security issues privately, not as a public issue. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: ''
+labels: enhancement
+---
+
+## Problem
+
+<!-- What are you trying to do, and what's getting in the way? -->
+
+## Proposed solution
+
+<!-- What you'd like to see happen. -->
+
+## Alternatives considered
+
+<!-- Other approaches you've thought about, if any. -->
+
+## Additional context
+
+<!-- Mockups, links, or related issues. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+PR titles must follow Conventional Commits (enforced by the "Conventional Commit"
+check), e.g. `feat: ...`, `fix: ...`, `docs: ...`, `ci: ...`, `chore: ...`.
+-->
+
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Checklist
+
+- [ ] `npm run lint` and `npm run check` pass
+- [ ] Tests added/updated where it makes sense (`npm run test:unit` / `npm run test:e2e`)
+- [ ] Database changes ship a migration and pass `npm run db:check` (migration safety)
+- [ ] `.env.example` / docs updated if configuration or behaviour changed


### PR DESCRIPTION
Closes #106.

Adds the repo-governance scaffolding: automatic reviewer routing plus consistent issue/PR structure.

## What's added

- **`.github/CODEOWNERS`** — global ownership so PRs auto-request a review.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — summary + linked issue + a checklist that reinforces existing gates (`lint`, `check`, `test:unit`/`test:e2e`, `db:check` migration safety) and reminds contributors of the Conventional-Commit title rule.
- **`.github/ISSUE_TEMPLATE/`** — `bug_report.md`, `feature_request.md`, and a `config.yml` whose contact link routes security reports to the private advisory flow (so they don't get filed as public issues — pairs with #102 / SECURITY.md).

## One thing to confirm

CODEOWNERS currently defaults everything to **@rubenhensen** (the dominant committer). If you'd rather route reviews to a **team** (e.g. `@encryption4all/<team>`) or split ownership by path (e.g. `drizzle/`, `.github/`, `src/lib/server/`), say the word — it's a one-line change.
