### PR TITLE
feat: add /readyz readiness probe with database check

### DIFF
--- a/src/routes/readyz/+server.ts
+++ b/src/routes/readyz/+server.ts
@@ -7,13 +7,21 @@ import type { RequestHandler } from './$types';
 // (i.e. the database is reachable). This is distinct from /health, which is a
 // pure liveness check. Orchestrator readiness gates should point here; the
 // container liveness HEALTHCHECK stays on /health.
+// A readiness verdict must never be cached: the endpoint flips between
+// 200/ready and 503/unavailable, and a stale cached response could mis-gate
+// traffic. Mark every response no-store so no intermediary reuses it.
+const NO_STORE = { 'Cache-Control': 'no-store' };
+
 export const GET: RequestHandler = async () => {
 	try {
 		await db.execute(sql`select 1`);
 	} catch (err) {
 		console.error('[readyz] database check failed', err);
-		return json({ status: 'unavailable', checks: { database: 'down' } }, { status: 503 });
+		return json(
+			{ status: 'unavailable', checks: { database: 'down' } },
+			{ status: 503, headers: NO_STORE }
+		);
 	}
 
-	return json({ status: 'ready', checks: { database: 'ok' } });
+	return json({ status: 'ready', checks: { database: 'ok' } }, { headers: NO_STORE });
 };

--- a/src/routes/readyz/+server.ts
+++ b/src/routes/readyz/+server.ts
@@ -1,0 +1,19 @@
+import { json } from '@sveltejs/kit';
+import { sql } from 'drizzle-orm';
+import { db } from '$lib/server/db';
+import type { RequestHandler } from './$types';
+
+// Readiness probe: reports 200 only when the app can actually serve traffic
+// (i.e. the database is reachable). This is distinct from /health, which is a
+// pure liveness check. Orchestrator readiness gates should point here; the
+// container liveness HEALTHCHECK stays on /health.
+export const GET: RequestHandler = async () => {
+	try {
+		await db.execute(sql`select 1`);
+	} catch (err) {
+		console.error('[readyz] database check failed', err);
+		return json({ status: 'unavailable', checks: { database: 'down' } }, { status: 503 });
+	}
+
+	return json({ status: 'ready', checks: { database: 'ok' } });
+};

--- a/tests/e2e/readyz.e2e.ts
+++ b/tests/e2e/readyz.e2e.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test('readiness endpoint reports ready when the database is reachable', async ({ request }) => {
+	const response = await request.get('/readyz');
+	expect(response.status()).toBe(200);
+	const body = await response.json();
+	expect(body.status).toBe('ready');
+	expect(body.checks.database).toBe('ok');
+});

--- a/tests/unit/readyz-endpoint.test.ts
+++ b/tests/unit/readyz-endpoint.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { executeMock } = vi.hoisted(() => ({
+	executeMock: vi.fn()
+}));
+
+vi.mock('$lib/server/db', () => ({ db: { execute: executeMock } }));
+
+vi.mock('drizzle-orm', () => ({
+	sql: (strings: TemplateStringsArray) => strings.join('')
+}));
+
+// SvelteKit's generated $types is not available under vitest; the endpoint only
+// uses the type import, so stub it out.
+vi.mock('./$types', () => ({}));
+
+import { GET } from '../../src/routes/readyz/+server';
+
+// The route handler only reads request-independent state, so an empty event is fine.
+const callGet = () => GET({} as never);
+
+describe('/readyz readiness probe', () => {
+	beforeEach(() => {
+		executeMock.mockReset();
+	});
+
+	it('returns 200/ready with no-store when the database is reachable', async () => {
+		executeMock.mockResolvedValueOnce(undefined);
+
+		const response = await callGet();
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('cache-control')).toBe('no-store');
+		expect(await response.json()).toEqual({ status: 'ready', checks: { database: 'ok' } });
+	});
+
+	it('returns 503/unavailable with no-store when the database check throws', async () => {
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+		executeMock.mockRejectedValueOnce(new Error('connection refused'));
+
+		const response = await callGet();
+
+		expect(response.status).toBe(503);
+		expect(response.headers.get('cache-control')).toBe('no-store');
+		expect(await response.json()).toEqual({
+			status: 'unavailable',
+			checks: { database: 'down' }
+		});
+		expect(consoleError).toHaveBeenCalled();
+
+		consoleError.mockRestore();
+	});
+});


### PR DESCRIPTION
Closes #97.

Adds a `/readyz` readiness probe, distinct from the existing `/health` liveness check.

## What & why

`/health` returns `{ status: 'ok' }` unconditionally — it says the process is up, not that it can serve traffic. `/readyz` runs a `select 1` against Postgres and returns:

- **200** `{ status: 'ready', checks: { database: 'ok' } }` when the DB is reachable;
- **503** `{ status: 'unavailable', checks: { database: 'down' } }` when it isn't.

This lets an orchestrator hold traffic when the database is unreachable. The container liveness `HEALTHCHECK` intentionally stays on `/health`; readiness gates should point at `/readyz`.

Covered by an e2e test (`tests/e2e/readyz.e2e.ts`) that mirrors the existing `health.e2e.ts` — in CI the Postgres service is up, so it asserts the 200/ready path.

## Scope notes

- **DB only** for now. Issue #97 also mentioned an IRMA reachability check and a fail-fast startup config validation; those are left out deliberately — a runtime IRMA ping needs a chosen health endpoint, and startup config validation belongs with the typed-env work in #98. Easy to layer on later.
