### PR TITLE
feat: configure explicit Postgres connection pool and timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@ PUBLIC_SITE_URL=http://localhost:5173
 
 # Database
 DATABASE_URL="postgres://user:password@localhost:5432/postguard_business"
+# Optional connection-pool tuning (postgres.js). Defaults are used if unset.
+# DB_POOL_MAX=10            # max pooled connections
+# DB_IDLE_TIMEOUT=20        # seconds before an idle connection is closed
+# DB_CONNECT_TIMEOUT=10     # seconds to wait when opening a connection
+# DB_MAX_LIFETIME=1800      # seconds before a connection is recycled
 
 # Yivi (YIVI_SERVER_URL and YIVI_SERVER_TOKEN set in docker-compose / k8s)
 YIVI_DEMO_ATTRIBUTES=true

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -6,7 +6,7 @@ import { env } from '$env/dynamic/private';
 if (!env.DATABASE_URL) throw new Error('DATABASE_URL is not set');
 
 // Parse a positive-integer env var, falling back to a default when unset/invalid.
-function intFromEnv(value: string | undefined, fallback: number): number {
+export function intFromEnv(value: string | undefined, fallback: number): number {
 	const parsed = Number(value);
 	return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -5,6 +5,20 @@ import { env } from '$env/dynamic/private';
 
 if (!env.DATABASE_URL) throw new Error('DATABASE_URL is not set');
 
-const client = postgres(env.DATABASE_URL);
+// Parse a positive-integer env var, falling back to a default when unset/invalid.
+function intFromEnv(value: string | undefined, fallback: number): number {
+	const parsed = Number(value);
+	return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+// Explicit pool sizing + timeouts. postgres.js otherwise leaves connect/idle
+// timeouts effectively unbounded, and `max` should be sized against Postgres
+// `max_connections` across replicas — so make it tunable via env.
+const client = postgres(env.DATABASE_URL, {
+	max: intFromEnv(env.DB_POOL_MAX, 10),
+	idle_timeout: intFromEnv(env.DB_IDLE_TIMEOUT, 20), // seconds
+	connect_timeout: intFromEnv(env.DB_CONNECT_TIMEOUT, 10), // seconds
+	max_lifetime: intFromEnv(env.DB_MAX_LIFETIME, 60 * 30) // seconds
+});
 
 export const db = drizzle(client, { schema });

--- a/tests/unit/db-pool.test.ts
+++ b/tests/unit/db-pool.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Stub the module's side-effectful imports so importing the db module doesn't
+// try to open a real connection at import time.
+vi.mock('$env/dynamic/private', () => ({
+	env: { DATABASE_URL: 'postgres://user:pass@localhost:5432/db' }
+}));
+vi.mock('postgres', () => ({ default: vi.fn(() => ({})) }));
+vi.mock('drizzle-orm/postgres-js', () => ({ drizzle: vi.fn(() => ({})) }));
+
+import { intFromEnv } from '$lib/server/db';
+
+describe('intFromEnv', () => {
+	it('parses a valid positive integer', () => {
+		expect(intFromEnv('25', 10)).toBe(25);
+	});
+
+	it('falls back when unset', () => {
+		expect(intFromEnv(undefined, 10)).toBe(10);
+	});
+
+	it('falls back on an empty string', () => {
+		expect(intFromEnv('', 10)).toBe(10);
+	});
+
+	it('falls back on a non-numeric value', () => {
+		expect(intFromEnv('abc', 10)).toBe(10);
+	});
+
+	it('falls back on zero and negative values', () => {
+		expect(intFromEnv('0', 10)).toBe(10);
+		expect(intFromEnv('-5', 10)).toBe(10);
+	});
+
+	it('falls back on a non-integer (float)', () => {
+		expect(intFromEnv('1.5', 10)).toBe(10);
+	});
+});


### PR DESCRIPTION
Closes #100.

Gives the app's Postgres client explicit, env-tunable pool sizing and timeouts. Previously `src/lib/server/db/index.ts` used `postgres(env.DATABASE_URL)` with library defaults (notably no connect/idle timeouts), and the pool couldn't be sized against Postgres `max_connections` across replicas.

## Changes

- `db/index.ts` now sets `max`, `idle_timeout`, `connect_timeout`, and `max_lifetime`, each overridable via env (`DB_POOL_MAX`, `DB_IDLE_TIMEOUT`, `DB_CONNECT_TIMEOUT`, `DB_MAX_LIFETIME`) with sensible defaults.
- `.env.example` documents the new optional knobs.

## Already covered

The other half of #100 — the migration script using a single short-lived connection — was **already** in place: `scripts/migrate.ts` uses `postgres(DATABASE_URL, { max: 1 })` and calls `client.end()`. No change needed there.
