### PR TITLE
docs: add LICENSE (MIT)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2021 Encryption 4 All
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -323,3 +323,7 @@ Internet → Ingress → business-svc:3000 → business-deployment
 ```
 
 The IRMA/Yivi server is accessed through SvelteKit's backend proxy (`/irma/[...path]`), which adds the authentication token. The browser never communicates directly with the IRMA server.
+
+## License
+
+[MIT](LICENSE) © Encryption 4 All

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "postguard-business",
 	"private": true,
 	"version": "1.3.1",
+	"license": "MIT",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
Closes #108.

Adds a `LICENSE` file — the repo had none, so default copyright applied and usage/contribution rights were ambiguous.

## Choice

Matches the main **encryption4all/postguard** repo: **MIT**, copied verbatim (including the `Copyright 2021 Encryption 4 All` line) so the two stay consistent. Also sets `"license": "MIT"` in `package.json`.

Say the word if you'd rather bump the copyright year or holder text.
