### PR TITLE
docs: disable blank issues to enforce template + security routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Report a security vulnerability
     url: https://github.com/encryption4all/postguard-business/security/advisories/new


### PR DESCRIPTION
Follow-up to #112 (already merged), addressing @dobby-coder's review nit on that PR.

Sets `blank_issues_enabled: false` in `.github/ISSUE_TEMPLATE/config.yml`. As Dobby noted, `contact_links` only *add* an entry to the issue chooser — with blank issues enabled, a contributor can still bypass the template and its security-advisory routing by opening a blank public issue. Disabling blank issues forces the chooser, which actually enforces the private security-report path that #102's SECURITY.md set up.

Ref #106.